### PR TITLE
feat: familiar link to player

### DIFF
--- a/JOining_Party_Select/Baf/JO_JOINI.BAF
+++ b/JOining_Party_Select/Baf/JO_JOINI.BAF
@@ -10,70 +10,80 @@ AddXPObject(AddXPObject(O:Object*,I:XP*) )
 
 // Broken links
 
-IF
-	Global("JO_LINK_PLAYER_ID","LOCALS",1)
-	Global("JO_JOIN_CUTSCENE","GLOBAL",0)
+IF // unexpected values
 	OR(2)
-		!InParty(Player1)
-		!Exists(Player1)
+		GlobalLT("JO_JOIN_LINK_PLAYER_ID","LOCALS",0)
+		GlobalGT("JO_JOIN_LINK_PLAYER_ID","LOCALS",6)
+	Global("JO_JOIN_CUTSCENE","GLOBAL",0)
 THEN
 	RESPONSE #100
-		SetGlobal("JO_LINK_PLAYER_ID","LOCALS",0)
+		SetGlobal("JO_JOIN_LINK_PLAYER_ID","LOCALS",0)
 END
 
 IF
-	Global("JO_LINK_PLAYER_ID","LOCALS",2)
+	Global("JO_JOIN_LINK_PLAYER_ID","LOCALS",1)
+	Global("JO_JOIN_CUTSCENE","GLOBAL",0)
+	OR(2)
+		!InParty(Player1)
+		!Exists(Player1) // TODO: useful ?
+THEN
+	RESPONSE #100
+		SetGlobal("JO_JOIN_LINK_PLAYER_ID","LOCALS",0)
+END
+
+IF
+	Global("JO_JOIN_LINK_PLAYER_ID","LOCALS",2)
 	Global("JO_JOIN_CUTSCENE","GLOBAL",0)
 	OR(2)
 		!InParty(Player2)
 		!Exists(Player2)
 THEN
 	RESPONSE #100
-		SetGlobal("JO_LINK_PLAYER_ID","LOCALS",0)
+		SetGlobal("JO_JOIN_LINK_PLAYER_ID","LOCALS",0)
 END
 
 IF
-	Global("JO_LINK_PLAYER_ID","LOCALS",3)
+	Global("JO_JOIN_LINK_PLAYER_ID","LOCALS",3)
 	Global("JO_JOIN_CUTSCENE","GLOBAL",0)
 	OR(2)
 		!InParty(Player3)
 		!Exists(Player3)
 THEN
 	RESPONSE #100
-		SetGlobal("JO_LINK_PLAYER_ID","LOCALS",0)
+		SetGlobal("JO_JOIN_LINK_PLAYER_ID","LOCALS",0)
 END
 
 IF
-	Global("JO_LINK_PLAYER_ID","LOCALS",4)
+	Global("JO_JOIN_LINK_PLAYER_ID","LOCALS",4)
 	Global("JO_JOIN_CUTSCENE","GLOBAL",0)
 	OR(2)
 		!InParty(Player4)
 		!Exists(Player4)
 THEN
 	RESPONSE #100
-		SetGlobal("JO_LINK_PLAYER_ID","LOCALS",0)
+		SetGlobal("JO_JOIN_LINK_PLAYER_ID","LOCALS",0)
 END
 
 IF
-	Global("JO_LINK_PLAYER_ID","LOCALS",5)
+	Global("JO_JOIN_LINK_PLAYER_ID","LOCALS",5)
 	Global("JO_JOIN_CUTSCENE","GLOBAL",0)
 	OR(2)
 		!InParty(Player5)
 		!Exists(Player5)
 THEN
 	RESPONSE #100
-		SetGlobal("JO_LINK_PLAYER_ID","LOCALS",0)
+		SetGlobal("JO_JOIN_LINK_PLAYER_ID","LOCALS",0)
 END
 
 IF
-	Global("JO_LINK_PLAYER_ID","LOCALS",6)
+	Global("JO_JOIN_LINK_PLAYER_ID","LOCALS",6)
 	Global("JO_JOIN_CUTSCENE","GLOBAL",0)
 	OR(2)
 		!InParty(Player6)
 		!Exists(Player6)
 THEN
 	RESPONSE #100
-		SetGlobal("JO_LINK_PLAYER_ID","LOCALS",0)
+		SetGlobal("JO_JOIN_LINK_PLAYER_ID","LOCALS",0)
 END
 
 
@@ -84,9 +94,9 @@ END
 
 // Large range or different area
 IF
-	Global("JO_LINK_PLAYER_ID","LOCALS",0)
-	!Global("JO_LINK_TYPE","LOCALS",0)
-	Global("JO_JOIN_CUTSCENE","GLOBAL",0)
+	Global("JO_JOIN_LINK_PLAYER_ID","LOCALS",0) // no linked
+	!Global("JO_JOIN_LINK_TYPE","LOCALS",-1) // != static mode
+	Global("JO_JOIN_CUTSCENE","GLOBAL",0) // no cutscene
 	Allegiance(Myself,FAMILIAR)
 	!Range(Player1Fill,70)
 THEN
@@ -96,13 +106,13 @@ END
 
 // Short range
 IF
-	Global("JO_LINK_PLAYER_ID","LOCALS",0)
-	!Global("JO_LINK_TYPE","LOCALS",0)
-	Global("JO_JOIN_CUTSCENE","GLOBAL",0)
+	Global("JO_JOIN_LINK_PLAYER_ID","LOCALS",0)
+	GlobalGT("JO_JOIN_LINK_TYPE","LOCALS",0) // follow with authorised move
+	Global("JO_JOIN_CUTSCENE","GLOBAL",0) // no cutscene
 	Allegiance(Myself,FAMILIAR)
 	!PersonalSpaceDistance(Player1Fill,5) // PersonalSpaceDistance is more reliable than Range at such a low range
 	OR(2)
-		Global("JO_LINK_TYPE","LOCALS",1)
+		Global("JO_JOIN_LINK_TYPE","LOCALS",2) // follow close
 		!Range(Player1Fill,50)
 THEN
 	RESPONSE #100
@@ -114,8 +124,8 @@ END
 
 // Large range or different area
 IF
-	Global("JO_LINK_PLAYER_ID","LOCALS",0)
-	!Global("JO_LINK_TYPE","LOCALS",0)
+	Global("JO_JOIN_LINK_PLAYER_ID","LOCALS",1)
+	!Global("JO_JOIN_LINK_TYPE","LOCALS",-1)
 	Global("JO_JOIN_CUTSCENE","GLOBAL",0)
 	Allegiance(Myself,FAMILIAR)
 	!Range(Player1,70)
@@ -126,13 +136,13 @@ END
 
 // Short range
 IF
-	Global("JO_LINK_PLAYER_ID","LOCALS",0)
-	!Global("JO_LINK_TYPE","LOCALS",0)
+	Global("JO_JOIN_LINK_PLAYER_ID","LOCALS",1)
+	GlobalGT("JO_JOIN_LINK_TYPE","LOCALS",0)
 	Global("JO_JOIN_CUTSCENE","GLOBAL",0)
 	Allegiance(Myself,FAMILIAR)
-	!PersonalSpaceDistance(Player1,5) // PersonalSpaceDistance is more reliable than Range at such a low range
+	!PersonalSpaceDistance(Player1,5)
 	OR(2)
-		Global("JO_LINK_TYPE","LOCALS",1)
+		Global("JO_JOIN_LINK_TYPE","LOCALS",2)
 		!Range(Player1,50)
 THEN
 	RESPONSE #100
@@ -144,8 +154,8 @@ END
 
 // Large range or different area
 IF
-	Global("JO_LINK_PLAYER_ID","LOCALS",0)
-	!Global("JO_LINK_TYPE","LOCALS",0)
+	Global("JO_JOIN_LINK_PLAYER_ID","LOCALS",2)
+	!Global("JO_JOIN_LINK_TYPE","LOCALS",-1)
 	Global("JO_JOIN_CUTSCENE","GLOBAL",0)
 	Allegiance(Myself,FAMILIAR)
 	!Range(Player2,70)
@@ -156,13 +166,13 @@ END
 
 // Short range
 IF
-	Global("JO_LINK_PLAYER_ID","LOCALS",0)
-	!Global("JO_LINK_TYPE","LOCALS",0)
+	Global("JO_JOIN_LINK_PLAYER_ID","LOCALS",2)
+	GlobalGT("JO_JOIN_LINK_TYPE","LOCALS",0)
 	Global("JO_JOIN_CUTSCENE","GLOBAL",0)
 	Allegiance(Myself,FAMILIAR)
-	!PersonalSpaceDistance(Player2,5) // PersonalSpaceDistance is more reliable than Range at such a low range
+	!PersonalSpaceDistance(Player2,5)
 	OR(2)
-		Global("JO_LINK_TYPE","LOCALS",1)
+		Global("JO_JOIN_LINK_TYPE","LOCALS",2)
 		!Range(Player2,50)
 THEN
 	RESPONSE #100
@@ -174,8 +184,8 @@ END
 
 // Large range or different area
 IF
-	Global("JO_LINK_PLAYER_ID","LOCALS",0)
-	!Global("JO_LINK_TYPE","LOCALS",0)
+	Global("JO_JOIN_LINK_PLAYER_ID","LOCALS",3)
+	!Global("JO_JOIN_LINK_TYPE","LOCALS",-1)
 	Global("JO_JOIN_CUTSCENE","GLOBAL",0)
 	Allegiance(Myself,FAMILIAR)
 	!Range(Player3,70)
@@ -186,13 +196,13 @@ END
 
 // Short range
 IF
-	Global("JO_LINK_PLAYER_ID","LOCALS",0)
-	!Global("JO_LINK_TYPE","LOCALS",0)
+	Global("JO_JOIN_LINK_PLAYER_ID","LOCALS",3)
+	GlobalGT("JO_JOIN_LINK_TYPE","LOCALS",0)
 	Global("JO_JOIN_CUTSCENE","GLOBAL",0)
 	Allegiance(Myself,FAMILIAR)
-	!PersonalSpaceDistance(Player3,5) // PersonalSpaceDistance is more reliable than Range at such a low range
+	!PersonalSpaceDistance(Player3,5)
 	OR(2)
-		Global("JO_LINK_TYPE","LOCALS",1)
+		Global("JO_JOIN_LINK_TYPE","LOCALS",2)
 		!Range(Player3,50)
 THEN
 	RESPONSE #100
@@ -204,8 +214,8 @@ END
 
 // Large range or different area
 IF
-	Global("JO_LINK_PLAYER_ID","LOCALS",0)
-	!Global("JO_LINK_TYPE","LOCALS",0)
+	Global("JO_JOIN_LINK_PLAYER_ID","LOCALS",4)
+	!Global("JO_JOIN_LINK_TYPE","LOCALS",-1)
 	Global("JO_JOIN_CUTSCENE","GLOBAL",0)
 	Allegiance(Myself,FAMILIAR)
 	!Range(Player4,70)
@@ -216,13 +226,13 @@ END
 
 // Short range
 IF
-	Global("JO_LINK_PLAYER_ID","LOCALS",0)
-	!Global("JO_LINK_TYPE","LOCALS",0)
+	Global("JO_JOIN_LINK_PLAYER_ID","LOCALS",4)
+	GlobalGT("JO_JOIN_LINK_TYPE","LOCALS",0)
 	Global("JO_JOIN_CUTSCENE","GLOBAL",0)
 	Allegiance(Myself,FAMILIAR)
-	!PersonalSpaceDistance(Player4,5) // PersonalSpaceDistance is more reliable than Range at such a low range
+	!PersonalSpaceDistance(Player4,5)
 	OR(2)
-		Global("JO_LINK_TYPE","LOCALS",1)
+		Global("JO_JOIN_LINK_TYPE","LOCALS",2)
 		!Range(Player4,50)
 THEN
 	RESPONSE #100
@@ -234,8 +244,8 @@ END
 
 // Large range or different area
 IF
-	Global("JO_LINK_PLAYER_ID","LOCALS",0)
-	!Global("JO_LINK_TYPE","LOCALS",0)
+	Global("JO_JOIN_LINK_PLAYER_ID","LOCALS",5)
+	!Global("JO_JOIN_LINK_TYPE","LOCALS",-1)
 	Global("JO_JOIN_CUTSCENE","GLOBAL",0)
 	Allegiance(Myself,FAMILIAR)
 	!Range(Player5,70)
@@ -246,13 +256,13 @@ END
 
 // Short range
 IF
-	Global("JO_LINK_PLAYER_ID","LOCALS",0)
-	!Global("JO_LINK_TYPE","LOCALS",0)
+	Global("JO_JOIN_LINK_PLAYER_ID","LOCALS",5)
+	GlobalGT("JO_JOIN_LINK_TYPE","LOCALS",0)
 	Global("JO_JOIN_CUTSCENE","GLOBAL",0)
 	Allegiance(Myself,FAMILIAR)
-	!PersonalSpaceDistance(Player5,5) // PersonalSpaceDistance is more reliable than Range at such a low range
+	!PersonalSpaceDistance(Player5,5)
 	OR(2)
-		Global("JO_LINK_TYPE","LOCALS",1)
+		Global("JO_JOIN_LINK_TYPE","LOCALS",2)
 		!Range(Player5,50)
 THEN
 	RESPONSE #100
@@ -264,8 +274,8 @@ END
 
 // Large range or different area
 IF
-	Global("JO_LINK_PLAYER_ID","LOCALS",0)
-	!Global("JO_LINK_TYPE","LOCALS",0)
+	Global("JO_JOIN_LINK_PLAYER_ID","LOCALS",6)
+	!Global("JO_JOIN_LINK_TYPE","LOCALS",-1)
 	Global("JO_JOIN_CUTSCENE","GLOBAL",0)
 	Allegiance(Myself,FAMILIAR)
 	!Range(Player6,70)
@@ -276,13 +286,13 @@ END
 
 // Short range
 IF
-	Global("JO_LINK_PLAYER_ID","LOCALS",0)
-	!Global("JO_LINK_TYPE","LOCALS",0)
+	Global("JO_JOIN_LINK_PLAYER_ID","LOCALS",6)
+	GlobalGT("JO_JOIN_LINK_TYPE","LOCALS",0)
 	Global("JO_JOIN_CUTSCENE","GLOBAL",0)
 	Allegiance(Myself,FAMILIAR)
-	!PersonalSpaceDistance(Player6,5) // PersonalSpaceDistance is more reliable than Range at such a low range
+	!PersonalSpaceDistance(Player6,5)
 	OR(2)
-		Global("JO_LINK_TYPE","LOCALS",1)
+		Global("JO_JOIN_LINK_TYPE","LOCALS",2)
 		!Range(Player6,50)
 THEN
 	RESPONSE #100
@@ -302,7 +312,7 @@ IF
 	OR(2)
 		!GlobalTimerNotExpired("JO_JOIN_JOIN","LOCALS")
 		OnCreation()
-	Switch("JO_LINK_PLAYER_ID","LOCALS")
+	Switch("JO_JOIN_LINK_PLAYER_ID","LOCALS")
 THEN
 	RESPONSE #0
 		ClearActions(Myself)

--- a/JOining_Party_Select/Baf/JO_JOINI.BAF
+++ b/JOining_Party_Select/Baf/JO_JOINI.BAF
@@ -308,6 +308,7 @@ IF
 	!ActuallyInCombat()
 	Allegiance(Myself,FAMILIAR)
 	Global("JO_NOJOIN","GLOBAL",0)
+	!Global("JO_JOIN_LINK_TYPE","LOCALS",-1) // != static mode
 	NumInPartyLT(6)
 	OR(2)
 		!GlobalTimerNotExpired("JO_JOIN_JOIN","LOCALS")
@@ -315,37 +316,30 @@ IF
 	Switch("JO_JOIN_LINK_PLAYER_ID","LOCALS")
 THEN
 	RESPONSE #0
-		ClearActions(Myself)
 		SetGlobal("JO_NOJOIN","GLOBAL",1)
 		MoveToObject(Player1Fill)
 		SetGlobal("JO_IS_JOINING","LOCALS",1)
 	RESPONSE #1
-		ClearActions(Myself)
 		SetGlobal("JO_NOJOIN","GLOBAL",1)
 		MoveToObject(Player1)
 		SetGlobal("JO_IS_JOINING","LOCALS",1)
 	RESPONSE #2
-		ClearActions(Myself)
 		SetGlobal("JO_NOJOIN","GLOBAL",1)
 		MoveToObject(Player2)
 		SetGlobal("JO_IS_JOINING","LOCALS",1)
 	RESPONSE #3
-		ClearActions(Myself)
 		SetGlobal("JO_NOJOIN","GLOBAL",1)
 		MoveToObject(Player3)
 		SetGlobal("JO_IS_JOINING","LOCALS",1)
 	RESPONSE #4
-		ClearActions(Myself)
 		SetGlobal("JO_NOJOIN","GLOBAL",1)
 		MoveToObject(Player4)
 		SetGlobal("JO_IS_JOINING","LOCALS",1)
 	RESPONSE #5
-		ClearActions(Myself)
 		SetGlobal("JO_NOJOIN","GLOBAL",1)
 		MoveToObject(Player5)
 		SetGlobal("JO_IS_JOINING","LOCALS",1)
 	RESPONSE #6
-		ClearActions(Myself)
 		SetGlobal("JO_NOJOIN","GLOBAL",1)
 		MoveToObject(Player6)
 		SetGlobal("JO_IS_JOINING","LOCALS",1)

--- a/JOining_Party_Select/Baf/JO_JOINI.BAF
+++ b/JOining_Party_Select/Baf/JO_JOINI.BAF
@@ -8,311 +8,339 @@ AddXPObject(AddXPObject(O:Object*,I:XP*) )
 
 ///////////////////////////////////////////////////////////////////////////////
 
-// To avoid Familiar / NPC being in another area when switching in and out of the party
-
-// Player1
+// Broken links
 
 IF
-	!Global("JO_JOIN_CLOSE_Player5","LOCALS",1)
-	!Global("JO_JOIN_CLOSE_Player4","LOCALS",1)
-	!Global("JO_JOIN_CLOSE_Player3","LOCALS",1)
-	!Global("JO_JOIN_CLOSE_Player2","LOCALS",1)
-	!Global("JO_JOIN_SIGHT_Player5","LOCALS",1)
-	!Global("JO_JOIN_SIGHT_Player4","LOCALS",1)
-	!Global("JO_JOIN_SIGHT_Player3","LOCALS",1)
-	!Global("JO_JOIN_SIGHT_Player2","LOCALS",1)
-	OR(2)
-		!Range(Player1,70)
-		!InMyArea(Player1)
-	!Global("JO_JOIN_NOFOLLOW","LOCALS",1)
+	Global("JO_LINK_PLAYER_ID","LOCALS",1)
 	Global("JO_JOIN_CUTSCENE","GLOBAL",0)
+	OR(2)
+		!InParty(Player1)
+		!Exists(Player1)
 THEN
 	RESPONSE #100
-//		MoveGlobalObject(Myself,Player1)
-		JumpToObject(Player1)
+		SetGlobal("JO_LINK_PLAYER_ID","LOCALS",0)
 END
 
-///////////////////////////////////////////////////////////////////////////////
-
-// Player2
-
-// No Player2
-
 IF
+	Global("JO_LINK_PLAYER_ID","LOCALS",2)
+	Global("JO_JOIN_CUTSCENE","GLOBAL",0)
 	OR(2)
 		!InParty(Player2)
 		!Exists(Player2)
-	OR(2)
-		Global("JO_JOIN_CLOSE_Player2","LOCALS",1)
-		Global("JO_JOIN_SIGHT_Player2","LOCALS",1)
-	!Global("JO_JOIN_NOFOLLOW","LOCALS",1)
-	Global("JO_JOIN_CUTSCENE","GLOBAL",0)
 THEN
 	RESPONSE #100
-		SetGlobal("JO_JOIN_CLOSE_Player2","LOCALS",0)
-		SetGlobal("JO_JOIN_SIGHT_Player2","LOCALS",0)
+		SetGlobal("JO_LINK_PLAYER_ID","LOCALS",0)
 END
 
-// Linked to Player2
-
 IF
-	OR(2)
-		Global("JO_JOIN_CLOSE_Player2","LOCALS",1)
-		Global("JO_JOIN_SIGHT_Player2","LOCALS",1)
-	OR(2)
-		!Range(Player2,70)
-		!InMyArea(Player2)
-	!Global("JO_JOIN_NOFOLLOW","LOCALS",1)
+	Global("JO_LINK_PLAYER_ID","LOCALS",3)
 	Global("JO_JOIN_CUTSCENE","GLOBAL",0)
-THEN
-	RESPONSE #100
-//		MoveGlobalObject(Myself,Player2)
-		JumpToObject(Player2)
-END
-
-///////////////////////////////////////////////////////////////////////////////
-
-// Player3
-
-// No Player3
-
-IF
 	OR(2)
 		!InParty(Player3)
 		!Exists(Player3)
-	OR(2)
-		Global("JO_JOIN_CLOSE_Player3","LOCALS",1)
-		Global("JO_JOIN_SIGHT_Player3","LOCALS",1)
-	!Global("JO_JOIN_NOFOLLOW","LOCALS",1)
-	Global("JO_JOIN_CUTSCENE","GLOBAL",0)
 THEN
 	RESPONSE #100
-		SetGlobal("JO_JOIN_CLOSE_Player3","LOCALS",0)
-		SetGlobal("JO_JOIN_SIGHT_Player3","LOCALS",0)
+		SetGlobal("JO_LINK_PLAYER_ID","LOCALS",0)
 END
 
-// Linked to Player3
-
 IF
-	OR(2)
-		Global("JO_JOIN_CLOSE_Player3","LOCALS",1)
-		Global("JO_JOIN_SIGHT_Player3","LOCALS",1)
-	OR(2)
-		!Range(Player3,70)
-		!InMyArea(Player3)
-	!Global("JO_JOIN_NOFOLLOW","LOCALS",1)
+	Global("JO_LINK_PLAYER_ID","LOCALS",4)
 	Global("JO_JOIN_CUTSCENE","GLOBAL",0)
-THEN
-	RESPONSE #100
-//		MoveGlobalObject(Myself,Player3)
-		JumpToObject(Player3)
-END
-
-///////////////////////////////////////////////////////////////////////////////
-
-// Player4
-
-// No Player4
-
-IF
 	OR(2)
 		!InParty(Player4)
 		!Exists(Player4)
-	OR(2)
-		Global("JO_JOIN_CLOSE_Player4","LOCALS",1)
-		Global("JO_JOIN_SIGHT_Player4","LOCALS",1)
-	!Global("JO_JOIN_NOFOLLOW","LOCALS",1)
-	Global("JO_JOIN_CUTSCENE","GLOBAL", 0)
 THEN
 	RESPONSE #100
-		SetGlobal("JO_JOIN_CLOSE_Player4","LOCALS",0)
-		SetGlobal("JO_JOIN_SIGHT_Player4","LOCALS",0)
+		SetGlobal("JO_LINK_PLAYER_ID","LOCALS",0)
 END
 
-// Linked to Player4
-
 IF
-	OR(2)
-		Global("JO_JOIN_CLOSE_Player4","LOCALS",1)
-		Global("JO_JOIN_SIGHT_Player4","LOCALS",1)
-	OR(2)
-		!Range(Player4,70)
-		!InMyArea(Player4)
-	!Global("JO_JOIN_NOFOLLOW","LOCALS",1)
-	Global("JO_JOIN_CUTSCENE","GLOBAL", 0)
-THEN
-	RESPONSE #100
-//		MoveGlobalObject(Myself,Player4)
-		JumpToObject(Player4)
-END
-
-///////////////////////////////////////////////////////////////////////////////
-
-// Player5
-
-// No Player5
-
-IF
+	Global("JO_LINK_PLAYER_ID","LOCALS",5)
+	Global("JO_JOIN_CUTSCENE","GLOBAL",0)
 	OR(2)
 		!InParty(Player5)
 		!Exists(Player5)
-	OR(2)
-		Global("JO_JOIN_CLOSE_Player5","LOCALS",1)
-		Global("JO_JOIN_SIGHT_Player5","LOCALS",1)
-	!Global("JO_JOIN_NOFOLLOW","LOCALS",1)
-	Global("JO_JOIN_CUTSCENE", "GLOBAL",0)
 THEN
 	RESPONSE #100
-		SetGlobal("JO_JOIN_CLOSE_Player5","LOCALS",0)
-		SetGlobal("JO_JOIN_SIGHT_Player5","LOCALS",0)
+		SetGlobal("JO_LINK_PLAYER_ID","LOCALS",0)
 END
+
+IF
+	Global("JO_LINK_PLAYER_ID","LOCALS",6)
+	Global("JO_JOIN_CUTSCENE","GLOBAL",0)
+	OR(2)
+		!InParty(Player6)
+		!Exists(Player6)
+THEN
+	RESPONSE #100
+		SetGlobal("JO_LINK_PLAYER_ID","LOCALS",0)
+END
+
+
+///////////////////////////////////////////////////////////////////////////////
+// Move to linked player
+
+// Familiar without link: the linked player is the first player in the party (which may not be Player1)
+
+// Large range or different area
+IF
+	Global("JO_LINK_PLAYER_ID","LOCALS",0)
+	!Global("JO_LINK_TYPE","LOCALS",0)
+	Global("JO_JOIN_CUTSCENE","GLOBAL",0)
+	Allegiance(Myself,FAMILIAR)
+	!Range(Player1Fill,70)
+THEN
+	RESPONSE #100
+		JumpToObject(Player1Fill)
+END
+
+// Short range
+IF
+	Global("JO_LINK_PLAYER_ID","LOCALS",0)
+	!Global("JO_LINK_TYPE","LOCALS",0)
+	Global("JO_JOIN_CUTSCENE","GLOBAL",0)
+	Allegiance(Myself,FAMILIAR)
+	!PersonalSpaceDistance(Player1Fill,5) // PersonalSpaceDistance is more reliable than Range at such a low range
+	OR(2)
+		Global("JO_LINK_TYPE","LOCALS",1)
+		!Range(Player1Fill,50)
+THEN
+	RESPONSE #100
+		MoveToObject(Player1Fill)
+END
+
+
+// Linked to Player1
+
+// Large range or different area
+IF
+	Global("JO_LINK_PLAYER_ID","LOCALS",0)
+	!Global("JO_LINK_TYPE","LOCALS",0)
+	Global("JO_JOIN_CUTSCENE","GLOBAL",0)
+	Allegiance(Myself,FAMILIAR)
+	!Range(Player1,70)
+THEN
+	RESPONSE #100
+		JumpToObject(Player1)
+END
+
+// Short range
+IF
+	Global("JO_LINK_PLAYER_ID","LOCALS",0)
+	!Global("JO_LINK_TYPE","LOCALS",0)
+	Global("JO_JOIN_CUTSCENE","GLOBAL",0)
+	Allegiance(Myself,FAMILIAR)
+	!PersonalSpaceDistance(Player1,5) // PersonalSpaceDistance is more reliable than Range at such a low range
+	OR(2)
+		Global("JO_LINK_TYPE","LOCALS",1)
+		!Range(Player1,50)
+THEN
+	RESPONSE #100
+		MoveToObject(Player1)
+END
+
+
+// Linked to Player2
+
+// Large range or different area
+IF
+	Global("JO_LINK_PLAYER_ID","LOCALS",0)
+	!Global("JO_LINK_TYPE","LOCALS",0)
+	Global("JO_JOIN_CUTSCENE","GLOBAL",0)
+	Allegiance(Myself,FAMILIAR)
+	!Range(Player2,70)
+THEN
+	RESPONSE #100
+		JumpToObject(Player2)
+END
+
+// Short range
+IF
+	Global("JO_LINK_PLAYER_ID","LOCALS",0)
+	!Global("JO_LINK_TYPE","LOCALS",0)
+	Global("JO_JOIN_CUTSCENE","GLOBAL",0)
+	Allegiance(Myself,FAMILIAR)
+	!PersonalSpaceDistance(Player2,5) // PersonalSpaceDistance is more reliable than Range at such a low range
+	OR(2)
+		Global("JO_LINK_TYPE","LOCALS",1)
+		!Range(Player2,50)
+THEN
+	RESPONSE #100
+		MoveToObject(Player2)
+END
+
+
+// Linked to Player3
+
+// Large range or different area
+IF
+	Global("JO_LINK_PLAYER_ID","LOCALS",0)
+	!Global("JO_LINK_TYPE","LOCALS",0)
+	Global("JO_JOIN_CUTSCENE","GLOBAL",0)
+	Allegiance(Myself,FAMILIAR)
+	!Range(Player3,70)
+THEN
+	RESPONSE #100
+		JumpToObject(Player3)
+END
+
+// Short range
+IF
+	Global("JO_LINK_PLAYER_ID","LOCALS",0)
+	!Global("JO_LINK_TYPE","LOCALS",0)
+	Global("JO_JOIN_CUTSCENE","GLOBAL",0)
+	Allegiance(Myself,FAMILIAR)
+	!PersonalSpaceDistance(Player3,5) // PersonalSpaceDistance is more reliable than Range at such a low range
+	OR(2)
+		Global("JO_LINK_TYPE","LOCALS",1)
+		!Range(Player3,50)
+THEN
+	RESPONSE #100
+		MoveToObject(Player3)
+END
+
+
+// Linked to Player4
+
+// Large range or different area
+IF
+	Global("JO_LINK_PLAYER_ID","LOCALS",0)
+	!Global("JO_LINK_TYPE","LOCALS",0)
+	Global("JO_JOIN_CUTSCENE","GLOBAL",0)
+	Allegiance(Myself,FAMILIAR)
+	!Range(Player4,70)
+THEN
+	RESPONSE #100
+		JumpToObject(Player4)
+END
+
+// Short range
+IF
+	Global("JO_LINK_PLAYER_ID","LOCALS",0)
+	!Global("JO_LINK_TYPE","LOCALS",0)
+	Global("JO_JOIN_CUTSCENE","GLOBAL",0)
+	Allegiance(Myself,FAMILIAR)
+	!PersonalSpaceDistance(Player4,5) // PersonalSpaceDistance is more reliable than Range at such a low range
+	OR(2)
+		Global("JO_LINK_TYPE","LOCALS",1)
+		!Range(Player4,50)
+THEN
+	RESPONSE #100
+		MoveToObject(Player4)
+END
+
 
 // Linked to Player5
 
+// Large range or different area
 IF
-	OR(2)
-		Global("JO_JOIN_CLOSE_Player5","LOCALS",1)
-		Global("JO_JOIN_SIGHT_Player5","LOCALS",1)
-	OR(2)
-		!Range(Player5,70)
-		!InMyArea(Player5)
-	!Global("JO_JOIN_NOFOLLOW","LOCALS",1)
-	Global("JO_JOIN_CUTSCENE", "GLOBAL",0)
+	Global("JO_LINK_PLAYER_ID","LOCALS",0)
+	!Global("JO_LINK_TYPE","LOCALS",0)
+	Global("JO_JOIN_CUTSCENE","GLOBAL",0)
+	Allegiance(Myself,FAMILIAR)
+	!Range(Player5,70)
 THEN
 	RESPONSE #100
-//		MoveGlobalObject(Myself,Player5)
 		JumpToObject(Player5)
 END
 
+// Short range
+IF
+	Global("JO_LINK_PLAYER_ID","LOCALS",0)
+	!Global("JO_LINK_TYPE","LOCALS",0)
+	Global("JO_JOIN_CUTSCENE","GLOBAL",0)
+	Allegiance(Myself,FAMILIAR)
+	!PersonalSpaceDistance(Player5,5) // PersonalSpaceDistance is more reliable than Range at such a low range
+	OR(2)
+		Global("JO_LINK_TYPE","LOCALS",1)
+		!Range(Player5,50)
+THEN
+	RESPONSE #100
+		MoveToObject(Player5)
+END
+
+
+// Linked to Player6
+
+// Large range or different area
+IF
+	Global("JO_LINK_PLAYER_ID","LOCALS",0)
+	!Global("JO_LINK_TYPE","LOCALS",0)
+	Global("JO_JOIN_CUTSCENE","GLOBAL",0)
+	Allegiance(Myself,FAMILIAR)
+	!Range(Player6,70)
+THEN
+	RESPONSE #100
+		JumpToObject(Player6)
+END
+
+// Short range
+IF
+	Global("JO_LINK_PLAYER_ID","LOCALS",0)
+	!Global("JO_LINK_TYPE","LOCALS",0)
+	Global("JO_JOIN_CUTSCENE","GLOBAL",0)
+	Allegiance(Myself,FAMILIAR)
+	!PersonalSpaceDistance(Player6,5) // PersonalSpaceDistance is more reliable than Range at such a low range
+	OR(2)
+		Global("JO_LINK_TYPE","LOCALS",1)
+		!Range(Player6,50)
+THEN
+	RESPONSE #100
+		MoveToObject(Player6)
+END
+
+
 ///////////////////////////////////////////////////////////////////////////////
-
-///////////////////////////////////////////////////////////////////////////////
-
-// Get close to PC before switching same reason as above
-
-// Player2
+// Go to Reintegrate NPC into party periodically
 
 IF
+	ActionListEmpty()
+	!ActuallyInCombat()
+	Allegiance(Myself,FAMILIAR)
+	Global("JO_NOJOIN","GLOBAL",0)
+	NumInPartyLT(6)
 	OR(2)
 		!GlobalTimerNotExpired("JO_JOIN_JOIN","LOCALS")
 		OnCreation()
-	Global("JO_JOIN_RANGE","LOCALS",0)
-	OR(2)
-		Global("JO_JOIN_CLOSE_Player2","LOCALS",1)
-		Global("JO_JOIN_SIGHT_Player2","LOCALS",1)
-	InMyArea(Player2)
-	ActionListEmpty()
-	NumInPartyLT(6)
-	CombatCounter(0)
-	Global("JO_NOJOIN","GLOBAL",0)
-//	Range(Player2,10)
+	Switch("JO_LINK_PLAYER_ID","LOCALS")
 THEN
-	RESPONSE #100
-		ClearAllActions()
+	RESPONSE #0
+		ClearActions(Myself)
 		SetGlobal("JO_NOJOIN","GLOBAL",1)
-		MoveToObject(Player2) // MoveToObjectFollow(Player2)
-		SetGlobal("JO_JOIN_RANGE","LOCALS",1) // Go to Reintegrate NPC into party periodically
+		MoveToObject(Player1Fill)
+		SetGlobal("JO_IS_JOINING","LOCALS",1)
+	RESPONSE #1
+		ClearActions(Myself)
+		SetGlobal("JO_NOJOIN","GLOBAL",1)
+		MoveToObject(Player1)
+		SetGlobal("JO_IS_JOINING","LOCALS",1)
+	RESPONSE #2
+		ClearActions(Myself)
+		SetGlobal("JO_NOJOIN","GLOBAL",1)
+		MoveToObject(Player2)
+		SetGlobal("JO_IS_JOINING","LOCALS",1)
+	RESPONSE #3
+		ClearActions(Myself)
+		SetGlobal("JO_NOJOIN","GLOBAL",1)
+		MoveToObject(Player3)
+		SetGlobal("JO_IS_JOINING","LOCALS",1)
+	RESPONSE #4
+		ClearActions(Myself)
+		SetGlobal("JO_NOJOIN","GLOBAL",1)
+		MoveToObject(Player4)
+		SetGlobal("JO_IS_JOINING","LOCALS",1)
+	RESPONSE #5
+		ClearActions(Myself)
+		SetGlobal("JO_NOJOIN","GLOBAL",1)
+		MoveToObject(Player5)
+		SetGlobal("JO_IS_JOINING","LOCALS",1)
+	RESPONSE #6
+		ClearActions(Myself)
+		SetGlobal("JO_NOJOIN","GLOBAL",1)
+		MoveToObject(Player6)
+		SetGlobal("JO_IS_JOINING","LOCALS",1)
 END
 
-// Player3
-
-IF
-	OR(2)
-		!GlobalTimerNotExpired("JO_JOIN_JOIN","LOCALS")
-		OnCreation()
-	Global("JO_JOIN_RANGE","LOCALS",0)
-	OR(2)
-		Global("JO_JOIN_CLOSE_Player3","LOCALS",1)
-		Global("JO_JOIN_SIGHT_Player3","LOCALS",1)
-	InMyArea(Player3)
-	ActionListEmpty()
-	NumInPartyLT(6)
-	CombatCounter(0)
-	Global("JO_NOJOIN","GLOBAL",0)
-//	Range(Player3,10)
-THEN
-	RESPONSE #100
-		ClearAllActions()
-		SetGlobal("JO_NOJOIN","GLOBAL",1)
-		MoveToObject(Player3) // MoveToObjectFollow(Player3)
-		SetGlobal("JO_JOIN_RANGE","LOCALS",1) // Go to Reintegrate NPC into party periodically
-END
-
-// Player4
-
-IF
-	OR(2)
-		!GlobalTimerNotExpired("JO_JOIN_JOIN","LOCALS")
-		OnCreation()
-	Global("JO_JOIN_RANGE","LOCALS",0)
-	OR(2)
-		Global("JO_JOIN_CLOSE_Player4","LOCALS",1)
-		Global("JO_JOIN_SIGHT_Player4","LOCALS",1)
-	InMyArea(Player4)
-	ActionListEmpty()
-	NumInPartyLT(6)
-	CombatCounter(0)
-	Global("JO_NOJOIN","GLOBAL",0)
-//	Range(Player4,10)
-THEN
-	RESPONSE #100
-		ClearAllActions()
-		SetGlobal("JO_NOJOIN","GLOBAL",1)
-		MoveToObject(Player4) // MoveToObjectFollow(Player4)
-		SetGlobal("JO_JOIN_RANGE","LOCALS",1) // Go to Reintegrate NPC into party periodically
-END
-
-// Player5
-
-IF
-	OR(2)
-		!GlobalTimerNotExpired("JO_JOIN_JOIN","LOCALS")
-		OnCreation()
-	Global("JO_JOIN_RANGE","LOCALS",0)
-	OR(2)
-		Global("JO_JOIN_CLOSE_Player5","LOCALS",1)
-		Global("JO_JOIN_SIGHT_Player5","LOCALS",1)
-	InMyArea(Player5)
-	ActionListEmpty()
-	NumInPartyLT(6)
-	CombatCounter(0)
-	Global("JO_NOJOIN","GLOBAL",0)
-//	Range(Player5,10)
-THEN
-	RESPONSE #100
-		ClearAllActions()
-		SetGlobal("JO_NOJOIN","GLOBAL",1)
-		MoveToObject(Player5) // MoveToObjectFollow(Player5)
-		SetGlobal("JO_JOIN_RANGE","LOCALS",1) // Go to Reintegrate NPC into party periodically
-END
-
-// Player1
-
-IF
-	OR(2)
-		!GlobalTimerNotExpired("JO_JOIN_JOIN","LOCALS")
-		OnCreation()
-	Global("JO_JOIN_RANGE","LOCALS",0)
-	!Global("JO_JOIN_CLOSE_Player5","LOCALS",1)
-	!Global("JO_JOIN_CLOSE_Player4","LOCALS",1)
-	!Global("JO_JOIN_CLOSE_Player3","LOCALS",1)
-	!Global("JO_JOIN_CLOSE_Player2","LOCALS",1)
-	!Global("JO_JOIN_SIGHT_Player5","LOCALS",1)
-	!Global("JO_JOIN_SIGHT_Player4","LOCALS",1)
-	!Global("JO_JOIN_SIGHT_Player3","LOCALS",1)
-	!Global("JO_JOIN_SIGHT_Player2","LOCALS",1)
-	Global("JO_NOJOIN","GLOBAL",0)
-	ActionListEmpty()
-	NumInPartyLT(6)
-	CombatCounter(0)
-//	Range(Player1,10)
-THEN
-	RESPONSE #100
-		ClearAllActions()
-		SetGlobal("JO_NOJOIN","GLOBAL",1)
-		MoveToObject(Player1) // MoveToObjectFollow(Player1)
-		SetGlobal("JO_JOIN_RANGE","LOCALS",1) // Go to Reintegrate NPC into party periodically
-END
 
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -323,15 +351,14 @@ END
 // Could be changed to more or less rounds for players convenience
 
 IF
-	Global("JO_JOIN_RANGE","LOCALS",1)
+	Global("JO_IS_JOINING","LOCALS",1)
 	ActionListEmpty()
 	NumInPartyLT(6)
-	CombatCounter(0)
+	!ActuallyInCombat()
 THEN
 	RESPONSE #100
 		SetInterrupt(FALSE)
-		SetGlobal("JO_JOIN_RANGE","LOCALS",0)
-//		SetGlobal("JO_NOJOIN","GLOBAL",1)
+		SetGlobal("JO_IS_JOINING","LOCALS",0)
 		SetGlobal("JO_JOINI","LOCALS",1)
 		SetGlobal("JO_JOIN_CLEAR","LOCALS",1) // ScriptAction (All_in_Baf)
 		EquipItemEx("JOMINHP1",1)
@@ -354,120 +381,6 @@ Returns true if the specified object has joined the party in the last script rou
 Returns true if the specified object has left the party in the last script round. This trigger is only sent to player characters. 
 */
 
-///////////////////////////////////////////////////////////////////////////////
-
-///////////////////////////////////////////////////////////////////////////////
-
-// All_In_D (We need to adjust our position)
-
-// Player1
-
-IF
-	Allegiance(Myself,FAMILIAR)
-	Global("JO_JOIN_SIGHT_Player1","LOCALS",1)
-	!Range(Player1,50)
-THEN
-	RESPONSE #100
-	MoveToObject(Player1)
-//	ProtectObject(Player1,30)
-END
-
-IF
-	Allegiance(Myself,FAMILIAR)
-	Global("JO_JOIN_CLOSE_Player1","LOCALS",1)
-	!Range(Player1,5)
-THEN
-	RESPONSE #100
-	MoveToObject(Player1)
-END
-
-// Player2
-
-IF
-	Allegiance(Myself,FAMILIAR)
-	Global("JO_JOIN_SIGHT_Player2","LOCALS",1)
-	!Range(Player2,50)
-THEN
-	RESPONSE #100
-	MoveToObject(Player2)
-//	ProtectObject(Player2,30)
-END
-
-IF
-	Allegiance(Myself,FAMILIAR)
-	Global("JO_JOIN_CLOSE_Player2","LOCALS",1)
-	!Range(Player2(Myself),5)
-THEN
-	RESPONSE #100
-	MoveToObject(Player2)
-END
-
-// Player3
-
-
-IF
-	Allegiance(Myself,FAMILIAR)
-	Global("JO_JOIN_SIGHT_Player3","LOCALS",1)
-	!Range(Player3,50)
-THEN
-	RESPONSE #100
-	MoveToObject(Player3)
-//	ProtectObject(Player3,30)
-END
-
-IF
-	Allegiance(Myself,FAMILIAR)
-	Global("JO_JOIN_CLOSE_Player3","LOCALS",1)
-	!Range(Player3,5)
-THEN
-	RESPONSE #100
-	MoveToObject(Player3)
-END
-
-// Player4
-
-
-IF
-	Allegiance(Myself,FAMILIAR)
-	Global("JO_JOIN_SIGHT_Player3","LOCALS",1)
-	!Range(Player4,50)
-THEN
-	RESPONSE #100
-	MoveToObject(Player4)
-//	ProtectObject(Player4,30)
-END
-
-IF
-	Allegiance(Myself,FAMILIAR)
-	Global("JO_JOIN_CLOSE_Player3","LOCALS",1)
-	!Range(Player4,5)
-THEN
-	RESPONSE #100
-	MoveToObject(Player4)
-END
-
-
-// Player5
-
-
-IF
-	Allegiance(Myself,FAMILIAR)
-	Global("JO_JOIN_SIGHT_Player5","LOCALS",1)
-	!Range(Player5,50)
-THEN
-	RESPONSE #100
-	MoveToObject(Player5)
-//	ProtectObject(Player5,30)
-END
-
-IF
-	Allegiance(Myself,FAMILIAR)
-	Global("JO_JOIN_CLOSE_Player5","LOCALS",1)
-	!Range(Player5,5)
-THEN
-	RESPONSE #100
-	MoveToObject(Player5)
-END
 
 ///////////////////////////////////////////////////////////////////////////////
 

--- a/JOining_Party_Select/Baf/JO_JOINI.BAF
+++ b/JOining_Party_Select/Baf/JO_JOINI.BAF
@@ -318,31 +318,31 @@ THEN
 	RESPONSE #0
 		SetGlobal("JO_NOJOIN","GLOBAL",1)
 		MoveToObject(Player1Fill)
-		SetGlobal("JO_IS_JOINING","LOCALS",1)
+		SetGlobal("JO_JOIN_IS_JOINING","LOCALS",1)
 	RESPONSE #1
 		SetGlobal("JO_NOJOIN","GLOBAL",1)
 		MoveToObject(Player1)
-		SetGlobal("JO_IS_JOINING","LOCALS",1)
+		SetGlobal("JO_JOIN_IS_JOINING","LOCALS",1)
 	RESPONSE #2
 		SetGlobal("JO_NOJOIN","GLOBAL",1)
 		MoveToObject(Player2)
-		SetGlobal("JO_IS_JOINING","LOCALS",1)
+		SetGlobal("JO_JOIN_IS_JOINING","LOCALS",1)
 	RESPONSE #3
 		SetGlobal("JO_NOJOIN","GLOBAL",1)
 		MoveToObject(Player3)
-		SetGlobal("JO_IS_JOINING","LOCALS",1)
+		SetGlobal("JO_JOIN_IS_JOINING","LOCALS",1)
 	RESPONSE #4
 		SetGlobal("JO_NOJOIN","GLOBAL",1)
 		MoveToObject(Player4)
-		SetGlobal("JO_IS_JOINING","LOCALS",1)
+		SetGlobal("JO_JOIN_IS_JOINING","LOCALS",1)
 	RESPONSE #5
 		SetGlobal("JO_NOJOIN","GLOBAL",1)
 		MoveToObject(Player5)
-		SetGlobal("JO_IS_JOINING","LOCALS",1)
+		SetGlobal("JO_JOIN_IS_JOINING","LOCALS",1)
 	RESPONSE #6
 		SetGlobal("JO_NOJOIN","GLOBAL",1)
 		MoveToObject(Player6)
-		SetGlobal("JO_IS_JOINING","LOCALS",1)
+		SetGlobal("JO_JOIN_IS_JOINING","LOCALS",1)
 END
 
 
@@ -355,14 +355,14 @@ END
 // Could be changed to more or less rounds for players convenience
 
 IF
-	Global("JO_IS_JOINING","LOCALS",1)
+	Global("JO_JOIN_IS_JOINING","LOCALS",1)
 	ActionListEmpty()
 	NumInPartyLT(6)
 	!ActuallyInCombat()
 THEN
 	RESPONSE #100
 		SetInterrupt(FALSE)
-		SetGlobal("JO_IS_JOINING","LOCALS",0)
+		SetGlobal("JO_JOIN_IS_JOINING","LOCALS",0)
 		SetGlobal("JO_JOINI","LOCALS",1)
 		SetGlobal("JO_JOIN_CLEAR","LOCALS",1) // ScriptAction (All_in_Baf)
 		EquipItemEx("JOMINHP1",1)

--- a/JOining_Party_Select/D/All_In.D
+++ b/JOining_Party_Select/D/All_In.D
@@ -45,56 +45,56 @@ END
 
 IF ~~ THEN BEGIN JO_JOINDLG3
 	SAY ~What do you need ?~
-	IF ~~ THEN REPLY ~Do whatever you want.~ DO ~SetGlobal("JO_LINK_TYPE","LOCALS",2)
-													SetGlobal("JO_LINK_PLAYER_ID","LOCALS",0)~ GOTO JO_JOINYes
-	IF ~~ THEN REPLY ~Stay at this location.~ DO ~SetGlobal("JO_LINK_TYPE","LOCALS",0)~ GOTO JO_JOINYes
+	IF ~~ THEN REPLY ~Do whatever you want.~ DO ~SetGlobal("JO_JOIN_LINK_TYPE","LOCALS",0)
+													SetGlobal("JO_JOIN_LINK_PLAYER_ID","LOCALS",0)~ GOTO JO_JOINYes
+	IF ~~ THEN REPLY ~Stay at this location.~ DO ~SetGlobal("JO_JOIN_LINK_TYPE","LOCALS",-1)~ GOTO JO_JOINYes
 	IF ~IsGabber(Player1)~
 		THEN REPLY ~Stay on sight.~
-			DO ~SetGlobal("JO_LINK_PLAYER_ID","LOCALS",1)
-					SetGlobal("JO_LINK_TYPE","LOCALS",2)~ GOTO JO_JOINYes
+			DO ~SetGlobal("JO_JOIN_LINK_PLAYER_ID","LOCALS",1)
+					SetGlobal("JO_JOIN_LINK_TYPE","LOCALS",1)~ GOTO JO_JOINYes
 	IF ~IsGabber(Player1)~
 		THEN REPLY ~Stay close.~
-			DO ~SetGlobal("JO_LINK_PLAYER_ID","LOCALS",1)
-					SetGlobal("JO_LINK_TYPE","LOCALS",1)~ GOTO JO_JOINYes
+			DO ~SetGlobal("JO_JOIN_LINK_PLAYER_ID","LOCALS",1)
+					SetGlobal("JO_JOIN_LINK_TYPE","LOCALS",2)~ GOTO JO_JOINYes
 	IF ~IsGabber(Player2)~
 		THEN REPLY ~Stay on sight.~
-			DO ~SetGlobal("JO_LINK_PLAYER_ID","LOCALS",2)
-					SetGlobal("JO_LINK_TYPE","LOCALS",2)~ GOTO JO_JOINYes
+			DO ~SetGlobal("JO_JOIN_LINK_PLAYER_ID","LOCALS",2)
+					SetGlobal("JO_JOIN_LINK_TYPE","LOCALS",1)~ GOTO JO_JOINYes
 	IF ~IsGabber(Player2)~
 		THEN REPLY ~Stay close.~
-			DO ~SetGlobal("JO_LINK_PLAYER_ID","LOCALS",2)
-					SetGlobal("JO_LINK_TYPE","LOCALS",1)~ GOTO JO_JOINYes
+			DO ~SetGlobal("JO_JOIN_LINK_PLAYER_ID","LOCALS",2)
+					SetGlobal("JO_JOIN_LINK_TYPE","LOCALS",2)~ GOTO JO_JOINYes
 	IF ~IsGabber(Player3)~
 		THEN REPLY ~Stay on sight.~
-			DO ~SetGlobal("JO_LINK_PLAYER_ID","LOCALS",3)
-					SetGlobal("JO_LINK_TYPE","LOCALS",2)~ GOTO JO_JOINYes
+			DO ~SetGlobal("JO_JOIN_LINK_PLAYER_ID","LOCALS",3)
+					SetGlobal("JO_JOIN_LINK_TYPE","LOCALS",1)~ GOTO JO_JOINYes
 	IF ~IsGabber(Player3)~
 		THEN REPLY ~Stay close.~
-			DO ~SetGlobal("JO_LINK_PLAYER_ID","LOCALS",3)
-					SetGlobal("JO_LINK_TYPE","LOCALS",1)~ GOTO JO_JOINYes
+			DO ~SetGlobal("JO_JOIN_LINK_PLAYER_ID","LOCALS",3)
+					SetGlobal("JO_JOIN_LINK_TYPE","LOCALS",2)~ GOTO JO_JOINYes
 	IF ~IsGabber(Player4)~
 		THEN REPLY ~Stay on sight.~
-			DO ~SetGlobal("JO_LINK_PLAYER_ID","LOCALS",4)
-					SetGlobal("JO_LINK_TYPE","LOCALS",2)~ GOTO JO_JOINYes
+			DO ~SetGlobal("JO_JOIN_LINK_PLAYER_ID","LOCALS",4)
+					SetGlobal("JO_JOIN_LINK_TYPE","LOCALS",1)~ GOTO JO_JOINYes
 	IF ~IsGabber(Player4)~
 		THEN REPLY ~Stay close.~
-			DO ~SetGlobal("JO_LINK_PLAYER_ID","LOCALS",4)
-					SetGlobal("JO_LINK_TYPE","LOCALS",1)~ GOTO JO_JOINYes
+			DO ~SetGlobal("JO_JOIN_LINK_PLAYER_ID","LOCALS",4)
+					SetGlobal("JO_JOIN_LINK_TYPE","LOCALS",2)~ GOTO JO_JOINYes
 	IF ~IsGabber(Player5)~
 		THEN REPLY ~Stay on sight.~
-			DO ~SetGlobal("JO_LINK_PLAYER_ID","LOCALS",5)
-					SetGlobal("JO_LINK_TYPE","LOCALS",2)~ GOTO JO_JOINYes
+			DO ~SetGlobal("JO_JOIN_LINK_PLAYER_ID","LOCALS",5)
+					SetGlobal("JO_JOIN_LINK_TYPE","LOCALS",1)~ GOTO JO_JOINYes
 	IF ~IsGabber(Player5)~
 		THEN REPLY ~Stay close.~
-			DO ~SetGlobal("JO_LINK_PLAYER_ID","LOCALS",5)
-					SetGlobal("JO_LINK_TYPE","LOCALS",1)~ GOTO JO_JOINYes
+			DO ~SetGlobal("JO_JOIN_LINK_PLAYER_ID","LOCALS",5)
+					SetGlobal("JO_JOIN_LINK_TYPE","LOCALS",2)~ GOTO JO_JOINYes
 	IF ~IsGabber(Player6)~
 		THEN REPLY ~Stay on sight.~
-			DO ~SetGlobal("JO_LINK_PLAYER_ID","LOCALS",6)
-					SetGlobal("JO_LINK_TYPE","LOCALS",2)~ GOTO JO_JOINYes
+			DO ~SetGlobal("JO_JOIN_LINK_PLAYER_ID","LOCALS",6)
+					SetGlobal("JO_JOIN_LINK_TYPE","LOCALS",1)~ GOTO JO_JOINYes
 	IF ~IsGabber(Player6)~
 		THEN REPLY ~Stay close.~
-			DO ~SetGlobal("JO_LINK_PLAYER_ID","LOCALS",6)
-					SetGlobal("JO_LINK_TYPE","LOCALS",1)~ GOTO JO_JOINYes
+			DO ~SetGlobal("JO_JOIN_LINK_PLAYER_ID","LOCALS",6)
+					SetGlobal("JO_JOIN_LINK_TYPE","LOCALS",2)~ GOTO JO_JOINYes
 END
 END

--- a/JOining_Party_Select/D/All_In.D
+++ b/JOining_Party_Select/D/All_In.D
@@ -45,136 +45,56 @@ END
 
 IF ~~ THEN BEGIN JO_JOINDLG3
 	SAY ~What do you need ?~
-	IF ~~ THEN REPLY ~Do whatever you want.~ DO ~SetGlobal("JO_JOIN_NOFOLLOW","LOCALS",0)
-													SetGlobal("JO_JOIN_SIGHT_Player1","LOCALS",0)
-													SetGlobal("JO_JOIN_CLOSE_Player1","LOCALS",0)
-													SetGlobal("JO_JOIN_SIGHT_Player2","LOCALS",0)
-													SetGlobal("JO_JOIN_CLOSE_Player2","LOCALS",0)
-													SetGlobal("JO_JOIN_SIGHT_Player3","LOCALS",0)
-													SetGlobal("JO_JOIN_CLOSE_Player3","LOCALS",0)
-													SetGlobal("JO_JOIN_SIGHT_Player4","LOCALS",0)
-													SetGlobal("JO_JOIN_CLOSE_Player4","LOCALS",0)
-													SetGlobal("JO_JOIN_SIGHT_Player5","LOCALS",0)
-													SetGlobal("JO_JOIN_CLOSE_Player5","LOCALS",0)~ GOTO JO_JOINYes
-	IF ~~ THEN REPLY ~Stay at this location.~ DO ~SetGlobal("JO_JOIN_NOFOLLOW","LOCALS",1)~ GOTO JO_JOINYes
+	IF ~~ THEN REPLY ~Do whatever you want.~ DO ~SetGlobal("JO_LINK_TYPE","LOCALS",2)
+													SetGlobal("JO_LINK_PLAYER_ID","LOCALS",0)~ GOTO JO_JOINYes
+	IF ~~ THEN REPLY ~Stay at this location.~ DO ~SetGlobal("JO_LINK_TYPE","LOCALS",0)~ GOTO JO_JOINYes
 	IF ~IsGabber(Player1)~
 		THEN REPLY ~Stay on sight.~
-			DO ~SetGlobal("JO_JOIN_SIGHT_Player1","LOCALS",1)
-					SetGlobal("JO_JOIN_CLOSE_Player1","LOCALS",0)
-					SetGlobal("JO_JOIN_SIGHT_Player2","LOCALS",0)
-					SetGlobal("JO_JOIN_CLOSE_Player2","LOCALS",0)
-					SetGlobal("JO_JOIN_SIGHT_Player3","LOCALS",0)
-					SetGlobal("JO_JOIN_CLOSE_Player3","LOCALS",0)
-					SetGlobal("JO_JOIN_SIGHT_Player4","LOCALS",0)
-					SetGlobal("JO_JOIN_CLOSE_Player4","LOCALS",0)
-					SetGlobal("JO_JOIN_SIGHT_Player5","LOCALS",0)
-					SetGlobal("JO_JOIN_CLOSE_Player5","LOCALS",0)~ GOTO JO_JOINYes
+			DO ~SetGlobal("JO_LINK_PLAYER_ID","LOCALS",1)
+					SetGlobal("JO_LINK_TYPE","LOCALS",2)~ GOTO JO_JOINYes
 	IF ~IsGabber(Player1)~
 		THEN REPLY ~Stay close.~
-			DO ~SetGlobal("JO_JOIN_CLOSE_Player1","LOCALS",1)
-					SetGlobal("JO_JOIN_SIGHT_Player1","LOCALS",0)
-					SetGlobal("JO_JOIN_SIGHT_Player2","LOCALS",0)
-					SetGlobal("JO_JOIN_CLOSE_Player2","LOCALS",0)
-					SetGlobal("JO_JOIN_SIGHT_Player3","LOCALS",0)
-					SetGlobal("JO_JOIN_CLOSE_Player3","LOCALS",0)
-					SetGlobal("JO_JOIN_SIGHT_Player4","LOCALS",0)
-					SetGlobal("JO_JOIN_CLOSE_Player4","LOCALS",0)
-					SetGlobal("JO_JOIN_SIGHT_Player5","LOCALS",0)
-					SetGlobal("JO_JOIN_CLOSE_Player5","LOCALS",0)~ GOTO JO_JOINYes
+			DO ~SetGlobal("JO_LINK_PLAYER_ID","LOCALS",1)
+					SetGlobal("JO_LINK_TYPE","LOCALS",1)~ GOTO JO_JOINYes
 	IF ~IsGabber(Player2)~
-	THEN REPLY ~Stay on sight.~
-		DO ~SetGlobal("JO_JOIN_SIGHT_Player2","LOCALS",1)
-				SetGlobal("JO_JOIN_CLOSE_Player2","LOCALS",0)
-				SetGlobal("JO_JOIN_CLOSE_Player1","LOCALS",0)
-				SetGlobal("JO_JOIN_SIGHT_Player1","LOCALS",0)
-				SetGlobal("JO_JOIN_SIGHT_Player3","LOCALS",0)
-				SetGlobal("JO_JOIN_CLOSE_Player3","LOCALS",0)
-				SetGlobal("JO_JOIN_SIGHT_Player4","LOCALS",0)
-				SetGlobal("JO_JOIN_CLOSE_Player4","LOCALS",0)
-				SetGlobal("JO_JOIN_SIGHT_Player5","LOCALS",0)
-				SetGlobal("JO_JOIN_CLOSE_Player5","LOCALS",0)~ GOTO JO_JOINYes
+		THEN REPLY ~Stay on sight.~
+			DO ~SetGlobal("JO_LINK_PLAYER_ID","LOCALS",2)
+					SetGlobal("JO_LINK_TYPE","LOCALS",2)~ GOTO JO_JOINYes
 	IF ~IsGabber(Player2)~
-	THEN REPLY ~Stay close.~
-		DO ~SetGlobal("JO_JOIN_CLOSE_Player2","LOCALS",1)
-				SetGlobal("JO_JOIN_SIGHT_Player2","LOCALS",0)
-				SetGlobal("JO_JOIN_CLOSE_Player1","LOCALS",0)
-				SetGlobal("JO_JOIN_SIGHT_Player1","LOCALS",0)
-				SetGlobal("JO_JOIN_SIGHT_Player3","LOCALS",0)
-				SetGlobal("JO_JOIN_CLOSE_Player3","LOCALS",0)
-				SetGlobal("JO_JOIN_SIGHT_Player4","LOCALS",0)
-				SetGlobal("JO_JOIN_CLOSE_Player4","LOCALS",0)
-				SetGlobal("JO_JOIN_SIGHT_Player5","LOCALS",0)
-				SetGlobal("JO_JOIN_CLOSE_Player5","LOCALS",0)~ GOTO JO_JOINYes
+		THEN REPLY ~Stay close.~
+			DO ~SetGlobal("JO_LINK_PLAYER_ID","LOCALS",2)
+					SetGlobal("JO_LINK_TYPE","LOCALS",1)~ GOTO JO_JOINYes
 	IF ~IsGabber(Player3)~
-	THEN REPLY ~Stay on sight.~
-		DO ~SetGlobal("JO_JOIN_SIGHT_Player3","LOCALS",1)
-				SetGlobal("JO_JOIN_CLOSE_Player3","LOCALS",0)
-				SetGlobal("JO_JOIN_CLOSE_Player1","LOCALS",0)
-				SetGlobal("JO_JOIN_SIGHT_Player1","LOCALS",0)
-				SetGlobal("JO_JOIN_SIGHT_Player2","LOCALS",0)
-				SetGlobal("JO_JOIN_CLOSE_Player2","LOCALS",0)
-				SetGlobal("JO_JOIN_SIGHT_Player4","LOCALS",0)
-				SetGlobal("JO_JOIN_CLOSE_Player4","LOCALS",0)
-				SetGlobal("JO_JOIN_SIGHT_Player5","LOCALS",0)
-				SetGlobal("JO_JOIN_CLOSE_Player5","LOCALS",0)~ GOTO JO_JOINYes
+		THEN REPLY ~Stay on sight.~
+			DO ~SetGlobal("JO_LINK_PLAYER_ID","LOCALS",3)
+					SetGlobal("JO_LINK_TYPE","LOCALS",2)~ GOTO JO_JOINYes
 	IF ~IsGabber(Player3)~
-	THEN REPLY ~Stay close.~
-		DO ~SetGlobal("JO_JOIN_CLOSE_Player3","LOCALS",1)
-				SetGlobal("JO_JOIN_SIGHT_Player3","LOCALS",0)
-				SetGlobal("JO_JOIN_CLOSE_Player1","LOCALS",0)
-				SetGlobal("JO_JOIN_SIGHT_Player1","LOCALS",0)
-				SetGlobal("JO_JOIN_SIGHT_Player2","LOCALS",0)
-				SetGlobal("JO_JOIN_CLOSE_Player2","LOCALS",0)
-				SetGlobal("JO_JOIN_SIGHT_Player4","LOCALS",0)
-				SetGlobal("JO_JOIN_CLOSE_Player4","LOCALS",0)
-				SetGlobal("JO_JOIN_SIGHT_Player5","LOCALS",0)
-				SetGlobal("JO_JOIN_CLOSE_Player5","LOCALS",0)~ GOTO JO_JOINYes
+		THEN REPLY ~Stay close.~
+			DO ~SetGlobal("JO_LINK_PLAYER_ID","LOCALS",3)
+					SetGlobal("JO_LINK_TYPE","LOCALS",1)~ GOTO JO_JOINYes
 	IF ~IsGabber(Player4)~
-	THEN REPLY ~Stay on sight.~
-		DO ~SetGlobal("JO_JOIN_SIGHT_Player4","LOCALS",1)
-				SetGlobal("JO_JOIN_CLOSE_Player4","LOCALS",0)
-				SetGlobal("JO_JOIN_CLOSE_Player1","LOCALS",0)
-				SetGlobal("JO_JOIN_SIGHT_Player1","LOCALS",0)
-				SetGlobal("JO_JOIN_SIGHT_Player2","LOCALS",0)
-				SetGlobal("JO_JOIN_CLOSE_Player2","LOCALS",0)
-				SetGlobal("JO_JOIN_CLOSE_Player3","LOCALS",0)
-				SetGlobal("JO_JOIN_SIGHT_Player5","LOCALS",0)
-				SetGlobal("JO_JOIN_CLOSE_Player5","LOCALS",0)~ GOTO JO_JOINYes
+		THEN REPLY ~Stay on sight.~
+			DO ~SetGlobal("JO_LINK_PLAYER_ID","LOCALS",4)
+					SetGlobal("JO_LINK_TYPE","LOCALS",2)~ GOTO JO_JOINYes
 	IF ~IsGabber(Player4)~
-	THEN REPLY ~Stay close.~
-		DO ~SetGlobal("JO_JOIN_CLOSE_Player4","LOCALS",1)
-				SetGlobal("JO_JOIN_SIGHT_Player4","LOCALS",0)
-				SetGlobal("JO_JOIN_CLOSE_Player1","LOCALS",0)
-				SetGlobal("JO_JOIN_SIGHT_Player1","LOCALS",0)
-				SetGlobal("JO_JOIN_SIGHT_Player2","LOCALS",0)
-				SetGlobal("JO_JOIN_CLOSE_Player2","LOCALS",0)
-				SetGlobal("JO_JOIN_SIGHT_Player3","LOCALS",0)
-				SetGlobal("JO_JOIN_CLOSE_Player3","LOCALS",0)
-				SetGlobal("JO_JOIN_SIGHT_Player5","LOCALS",0)
-				SetGlobal("JO_JOIN_CLOSE_Player5","LOCALS",0)~ GOTO JO_JOINYes
+		THEN REPLY ~Stay close.~
+			DO ~SetGlobal("JO_LINK_PLAYER_ID","LOCALS",4)
+					SetGlobal("JO_LINK_TYPE","LOCALS",1)~ GOTO JO_JOINYes
 	IF ~IsGabber(Player5)~
-	THEN REPLY ~Stay on sight.~
-		DO ~SetGlobal("JO_JOIN_SIGHT_Player5","LOCALS",1)
-				SetGlobal("JO_JOIN_CLOSE_Player5","LOCALS",0)
-				SetGlobal("JO_JOIN_CLOSE_Player1","LOCALS",0)
-				SetGlobal("JO_JOIN_SIGHT_Player1","LOCALS",0)
-				SetGlobal("JO_JOIN_SIGHT_Player2","LOCALS",0)
-				SetGlobal("JO_JOIN_CLOSE_Player2","LOCALS",0)
-				SetGlobal("JO_JOIN_SIGHT_Player3","LOCALS",0)
-				SetGlobal("JO_JOIN_CLOSE_Player3","LOCALS",0)
-				SetGlobal("JO_JOIN_SIGHT_Player4","LOCALS",0)
-				SetGlobal("JO_JOIN_CLOSE_Player4","LOCALS",0)~ GOTO JO_JOINYes
+		THEN REPLY ~Stay on sight.~
+			DO ~SetGlobal("JO_LINK_PLAYER_ID","LOCALS",5)
+					SetGlobal("JO_LINK_TYPE","LOCALS",2)~ GOTO JO_JOINYes
 	IF ~IsGabber(Player5)~
-	THEN REPLY ~Stay close.~
-		DO ~SetGlobal("JO_JOIN_CLOSE_Player5","LOCALS",1)
-				SetGlobal("JO_JOIN_SIGHT_Player5","LOCALS",0)
-				SetGlobal("JO_JOIN_CLOSE_Player1","LOCALS",0)
-				SetGlobal("JO_JOIN_SIGHT_Player1","LOCALS",0)
-				SetGlobal("JO_JOIN_SIGHT_Player2","LOCALS",0)
-				SetGlobal("JO_JOIN_CLOSE_Player2","LOCALS",0)
-				SetGlobal("JO_JOIN_SIGHT_Player3","LOCALS",0)
-				SetGlobal("JO_JOIN_CLOSE_Player3","LOCALS",0)
-				SetGlobal("JO_JOIN_SIGHT_Player4","LOCALS",0)
-				SetGlobal("JO_JOIN_CLOSE_Player4","LOCALS",0)~ GOTO JO_JOINYes
+		THEN REPLY ~Stay close.~
+			DO ~SetGlobal("JO_LINK_PLAYER_ID","LOCALS",5)
+					SetGlobal("JO_LINK_TYPE","LOCALS",1)~ GOTO JO_JOINYes
+	IF ~IsGabber(Player6)~
+		THEN REPLY ~Stay on sight.~
+			DO ~SetGlobal("JO_LINK_PLAYER_ID","LOCALS",6)
+					SetGlobal("JO_LINK_TYPE","LOCALS",2)~ GOTO JO_JOINYes
+	IF ~IsGabber(Player6)~
+		THEN REPLY ~Stay close.~
+			DO ~SetGlobal("JO_LINK_PLAYER_ID","LOCALS",6)
+					SetGlobal("JO_LINK_TYPE","LOCALS",1)~ GOTO JO_JOINYes
 END
 END

--- a/Readme.md
+++ b/Readme.md
@@ -176,13 +176,20 @@ LOCALS :
 
 ---
 
-- Global("JO_JOIN_CLOSE_PlayerX","LOCALS",0)
+- Global("JO_LINK_PLAYER_ID","LOCALS",X)
    - Through dialog with familiar, used to link a familiar to a specific party member. See All_In.D
+   - 0: Player1Fill
+   - 1: Player1
+   ...
+   - 6: Player6
 
 ---
 
-- Global("JO_JOIN_SIGHT_PlayerX","LOCALS",0)
+- Global("JO_LINK_TYPE","LOCALS",X)
    - Through dialog with familiar, used to link a familiar to a specific party member. See All_In.D
+   - 0: No follow
+   - 1: Close, range 5
+   - 2: Sight, range 50
 
 ---
 
@@ -213,7 +220,7 @@ LOCALS :
 
 ---
 
-- Global("JO_JOIN_RANGE","LOCALS",0)
+- Global("JO_IS_JOINING","LOCALS",0)
    - The familiar will go close to Charname or linked party member before switching in party.
 
 ---

--- a/Readme.md
+++ b/Readme.md
@@ -222,7 +222,7 @@ LOCALS :
 
 ---
 
-- Global("JO_IS_JOINING","LOCALS",0)
+- Global("JO_JOIN_IS_JOINING","LOCALS",0)
    - The familiar will go close to Charname or linked party member before switching in party.
 
 ---

--- a/Readme.md
+++ b/Readme.md
@@ -176,20 +176,22 @@ LOCALS :
 
 ---
 
-- Global("JO_LINK_PLAYER_ID","LOCALS",X)
+- Global("JO_JOIN_LINK_PLAYER_ID","LOCALS",X)
    - Through dialog with familiar, used to link a familiar to a specific party member. See All_In.D
-   - 0: Player1Fill
+   - 0: Player1Fill (default case)
    - 1: Player1
-   ...
+   - ...
    - 6: Player6
+   - Other: Player1Fill
 
 ---
 
-- Global("JO_LINK_TYPE","LOCALS",X)
+- Global("JO_JOIN_LINK_TYPE","LOCALS",X)
    - Through dialog with familiar, used to link a familiar to a specific party member. See All_In.D
-   - 0: No follow
-   - 1: Close, range 5
-   - 2: Sight, range 50
+   - -1: Static, no move or teleport
+   - 0: Do anything, no move but teleport if range > 70 (default case)
+   - 1: Sight, teleport if > 70, move if range > 50
+   - 2: Close, teleport if > 70, move if range > 5
 
 ---
 


### PR DESCRIPTION
PR de mise à jour des liens entre les personnages joueurs et les familiers.

- `JO_JOIN_CLOSE_PlayerX` et `JO_JOIN_SIGHT_PlayerX` sont fondus dans `JO_JOIN_LINK_PLAYER_ID` et `JO_JOIN_LINK_TYPE`
  - `JO_JOIN_LINK_PLAYER_ID` contient l'id du slot du joueur (0 à 6)
  - `JO_JOIN_LINK_TYPE` contient le type de lien avec le joueur (proche, distant, ne suit pas)
  - On a 2 variables plutôt que 10+, en activer une, revient à désactiver les autres
- `JO_JOIN_RANGE` est renommé `JO_JOIN_IS_JOINING`

Parmi les nouveautés on a :
- Feat : Le familier peut être lié à Player6 (en soi rien n'empêche d'avoir une équipe de 6 + des familiers et on peut avoir un Player6 dans un groupe de 5)
- Fix : `ClearAllActions()` a été retiré
- Edge case : Si JO_JOIN_LINK_PLAYER_ID vaut 0, le familier est lié à `Player1Fill` plutôt que `Player1`
- Edge case : Remplacement de `!Range(PlayerX,5)` par `!PersonalSpaceDistance(PlayerX,5)` car plus fiable si on a des personnages avec des gros cercles de sélection
- Edge case : Remplacement de `CombatCounter(0)` par `!ActuallyInCombat()`, plus fiable
- Opti : `!Range(PlayerX,70)` renvoie vrai si la distance est >= 70 mais aussi si les personnages ne sont pas sur la même zone

On dirait pas trop dans la PR, parce qu'il y a beaucoup de changement mais l'idée reste la même :
1. Si on est lié à un personnage qui n'existe plus, on met JO_JOIN_LINK_PLAYER_ID à 0
2. Si le familier n'est pas dans la même map ou s'il est trop loin de son "maître" il se téléporte à lui
3. Il se déplace vers lui si la distance est importante en fonction de la valeur de `JO_JOIN_LINK_TYPE`
4. Quand il essaye de switcher, le familier se déplace vers son maître

