### PR TITLE
fix: NOJOIN

### DIFF
--- a/JOining_Party_Select/Baf/All_In.BAF
+++ b/JOining_Party_Select/Baf/All_In.BAF
@@ -148,7 +148,6 @@ THEN
 	RESPONSE #100
 		SetInterrupt(FALSE)
 		LeaveParty()
-		SetGlobal("JO_NOJOIN","GLOBAL",0)
 		SmallWait(1)
 		GiveItemCreate("JOMINHP1",Myself,0,0,0)
 		SmallWait(1)
@@ -175,7 +174,6 @@ THEN
 	RESPONSE #100
 		SetGlobal("JO_JOIN_TALK","LOCALS",0)
 		DisplayStringHead(Myself,~We are now fellow travelers.~)
-		SetGlobal("JO_NOJOIN","GLOBAL",0)
 END
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Parce que lancer la compétence sur un membre du groupe ne doit pas réinitialiser le NOJOIN.
Sinon plusieurs familiers peuvent se déplacer au même temps.

Cas d'usage :
Un familier se déplace, NOJOIN = 1.
Pendant ce temps, j'utilise ma compétence sur un membre du groupe, NOJOIN = 0.
Un autre familier se déplace, NOJOIN = 1.
Le personnage devenu familier dit `We are now fellow travelers.`, NOJOIN = 0.
Un autre familier se déplace, NOJOIN = 1.
