### PR TITLE
Transition situation

### DIFF
--- a/JOining_Party_Select/Baf/All_In.BAF
+++ b/JOining_Party_Select/Baf/All_In.BAF
@@ -97,38 +97,11 @@ END
 ///////////////////////////////////////////////////////////////////////////////
 
 IF
-	Global("JO_TRAVELER_%Death_var%","GLOBAL",1)
-	OR(2)
-		Global("JO_Myself_LeaveParty","LOCALS",1)
-		Global("JO_%Death_var%_LeaveParty","GLOBAL",1)
-	!InParty(Myself)
-THEN
-	RESPONSE #100
-		JoinParty()
-END
-
-IF
-	OR(2)
-		Global("JO_Myself_LeaveParty","LOCALS",1)
-		Global("JO_%Death_var%_LeaveParty","GLOBAL",1)
-	InParty(Myself)
-THEN
-	RESPONSE #100
-		SetGlobal("JO_TRAVELER_%Death_var%","GLOBAL",0)
-		SetGlobal("JO_Myself_LeaveParty","LOCALS",0)
-		SetGlobal("JO_%Death_var%_LeaveParty","GLOBAL",0)
-		SetGlobal("JO_JOIN_IS_JOINING","LOCALS",0)
-		SetGlobal("JO_JOIN","LOCALS",0)
-		SetGlobal("JO_JOINI","LOCALS",0)
-		LeaveParty()
-END
-
-IF
 	!AreaCheck("BD0120")
 	Global("JO_JOIN_SLEEPING_DEAD","LOCALS",0)
 	!Allegiance(Myself,FAMILIAR)
 	Global("JO_TRAVELER_%Death_var%","GLOBAL",1)
-	!Global("JO_JOIN","LOCALS",1)
+	Global("JO_JOIN","LOCALS",0)
 THEN
 	RESPONSE #100
 		SetGlobal("JO_TRAVELER_%Death_var%","GLOBAL",0)

--- a/JOining_Party_Select/Baf/JO_FLYI.BAF
+++ b/JOining_Party_Select/Baf/JO_FLYI.BAF
@@ -1,0 +1,59 @@
+/*
+IF
+	Allegiance(Myself,FAMILIAR)
+THEN
+	RESPONSE #100
+	ChangeAIScript("JO_FLYI",GENERAL)
+END
+*/
+
+IF
+	OR(2)
+		Allegiance(Myself,FAMILIAR)
+		!InParty(Myself)
+	NumInPartyLT(6)
+THEN
+	RESPONSE #100
+		JoinParty()
+		Continue()
+END
+
+IF
+	OR(3)
+		!Global("JO_Myself_LeaveParty","LOCALS",0)
+		!Global("JO_%Death_var%_LeaveParty","GLOBAL",0)
+		!Global("JO_TRAVELER_%Death_var%","GLOBAL",0)
+	InParty(Myself)
+THEN
+	RESPONSE #100
+		SetGlobal("JO_TRAVELER_%Death_var%","GLOBAL",0)
+		SetGlobal("JO_Myself_LeaveParty","LOCALS",0)
+		SetGlobal("JO_%Death_var%_LeaveParty","GLOBAL",0)
+		SetGlobal("JO_JOIN_IS_JOINING","LOCALS",0)
+		SetGlobal("JO_JOIN","LOCALS",0)
+		SetGlobal("JO_JOINI","LOCALS",0)
+		ChangeAIScript("",GENERAL)
+		LeaveParty()
+END
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/JOining_Party_Select/Baf/JO_JOIN/JO_JOINBG1.BAF
+++ b/JOining_Party_Select/Baf/JO_JOIN/JO_JOINBG1.BAF
@@ -20,6 +20,7 @@ THEN
 		Continue()
 END
 
+/*
 IF
 	Global("JO_TRAVELER_%Death_var%","GLOBAL",1)
 	OR(2)
@@ -37,6 +38,7 @@ THEN
 		SetGlobal("JO_%Death_var%_LeaveParty","GLOBAL",0)
 		Continue()
 END
+*/
 
  // SoD
 
@@ -52,6 +54,7 @@ THEN
 		Continue()
 END
 
+/*
 IF
 	Global("JO_TRAVELER_%Death_var%","GLOBAL",1)
 	OR(2)
@@ -67,6 +70,7 @@ THEN
 		SetGlobal("JO_%Death_var%_LeaveParty","GLOBAL",0)
 		Continue()
 END
+*/
 
 ////////////////////////////////////////////////////
 

--- a/JOining_Party_Select/Baf/JO_JOINI.BAF
+++ b/JOining_Party_Select/Baf/JO_JOINI.BAF
@@ -524,7 +524,7 @@ THEN
 	SmallWait(1)
 	SetGlobal("JO_JOIN_SLEEPING_DEAD","LOCALS",1)
 	RESPONSE #10
-	DisplayStringHead(Myself,#4888)
+	VerbalConstant(Myself,DYING)
 	SmallWait(1)
 	SetGlobal("JO_JOIN_SLEEPING_DEAD","LOCALS",1)
 	RESPONSE #10
@@ -585,9 +585,11 @@ END
 
 IF
 	Global("JO_JOIN_SLEEPING_DEAD","LOCALS",2)
-	OR(2)
+	OR(3)
 		!GlobalTimerNotExpired("JO_JOIN_TIMER_DEAD","LOCALS")
 		HPGT(Myself,4)
+		!ActuallyInCombat()
+		
 THEN
 	RESPONSE #10
 	SetInterrupt(FALSE)

--- a/JOining_Party_Select/JOining_Party_Select.tp2
+++ b/JOining_Party_Select/JOining_Party_Select.tp2
@@ -207,15 +207,57 @@ LANGUAGE ~English~
 /////////////////////////// Continuous NPCs ///////////////////////////
 
 
-BEGIN ~Continuous original NPCs (Imoen, Edwin, Jaheira, Minsc, Viconia, Dorn, Neera, Rasaad)~
+BEGIN ~Include Imoen~
 DESIGNATED 10
-LABEL ~JOining_Party_Select-Continuous~
+SUBCOMPONENT ~Continuous original NPCs (Imoen, Edwin, Jaheira, Minsc, Viconia, Dorn, Neera, Rasaad)~
+LABEL ~JOining_Party_Select-Continuous_Imoen~
 REQUIRE_PREDICATE (GAME_IS ~tob bgt bgee bg2ee eet~) ~Necessite BG2-ToB / BG2EE / BGT / EET~
 
 		COPY ~weidu_external/JOining_Party_Select~ ~weidu_external/JOining_Party_Select~
 			REPLACE_TEXTUALLY ~// Original Imoen~ ~~
 			REPLACE_TEXTUALLY ~// %Don_t_replace_anything_ODD%~ ~~
 			REPLACE_TEXTUALLY ~// %Don_t_replace_anything_END%~ ~~
+
+		COPY ~weidu_external/JOining_Party_Select~ ~weidu_external/JOining_Party_Select~
+			REPLACE_TEXTUALLY ~// Original Edwin~ ~~
+			REPLACE_TEXTUALLY ~// %Don_t_replace_anything_ODD%~ ~~
+			REPLACE_TEXTUALLY ~// %Don_t_replace_anything_END%~ ~~
+
+		COPY ~weidu_external/JOining_Party_Select~ ~weidu_external/JOining_Party_Select~
+			REPLACE_TEXTUALLY ~// Original Jaheira~ ~~
+			REPLACE_TEXTUALLY ~// %Don_t_replace_anything_ODD%~ ~~
+			REPLACE_TEXTUALLY ~// %Don_t_replace_anything_END%~ ~~
+
+		COPY ~weidu_external/JOining_Party_Select~ ~weidu_external/JOining_Party_Select~
+			REPLACE_TEXTUALLY ~// Original Minsc~ ~~
+			REPLACE_TEXTUALLY ~// %Don_t_replace_anything_ODD%~ ~~
+			REPLACE_TEXTUALLY ~// %Don_t_replace_anything_END%~ ~~
+
+		COPY ~weidu_external/JOining_Party_Select~ ~weidu_external/JOining_Party_Select~
+			REPLACE_TEXTUALLY ~// Original Viconia~ ~~
+			REPLACE_TEXTUALLY ~// %Don_t_replace_anything_ODD%~ ~~
+			REPLACE_TEXTUALLY ~// %Don_t_replace_anything_END%~ ~~
+			
+		COPY ~weidu_external/JOining_Party_Select~ ~weidu_external/JOining_Party_Select~
+			REPLACE_TEXTUALLY ~// Original Dorn~ ~~
+			REPLACE_TEXTUALLY ~// %Don_t_replace_anything_ODD%~ ~~
+			REPLACE_TEXTUALLY ~// %Don_t_replace_anything_END%~ ~~
+
+		COPY ~weidu_external/JOining_Party_Select~ ~weidu_external/JOining_Party_Select~
+			REPLACE_TEXTUALLY ~// Original Neera~ ~~
+			REPLACE_TEXTUALLY ~// %Don_t_replace_anything_ODD%~ ~~
+			REPLACE_TEXTUALLY ~// %Don_t_replace_anything_END%~ ~~
+
+		COPY ~weidu_external/JOining_Party_Select~ ~weidu_external/JOining_Party_Select~
+			REPLACE_TEXTUALLY ~// Original Rasaad~ ~~
+			REPLACE_TEXTUALLY ~// %Don_t_replace_anything_ODD%~ ~~
+			REPLACE_TEXTUALLY ~// %Don_t_replace_anything_END%~ ~~
+
+BEGIN ~Exlude Imoen~
+DESIGNATED 11
+SUBCOMPONENT ~Continuous original NPCs (Imoen, Edwin, Jaheira, Minsc, Viconia, Dorn, Neera, Rasaad)~
+LABEL ~JOining_Party_Select-Continuous_Not_Imoen~
+REQUIRE_PREDICATE (GAME_IS ~tob bgt bgee bg2ee eet~) ~Necessite BG2-ToB / BG2EE / BGT / EET~
 
 		COPY ~weidu_external/JOining_Party_Select~ ~weidu_external/JOining_Party_Select~
 			REPLACE_TEXTUALLY ~// Original Edwin~ ~~

--- a/JOining_Party_Select/Lib/JOining_Party_Select_BCS.tph
+++ b/JOining_Party_Select/Lib/JOining_Party_Select_BCS.tph
@@ -516,7 +516,8 @@ BEGIN
 			PATCH_IF (num_matches > 0) BEGIN
 				REPLACE_TEXTUALLY CASE_INSENSITIVE ~%textToReplace%~ ~\0
 		SetGlobal("JO_%Death_var%_LeaveParty","GLOBAL",1)
-		Wait(4)~
+		SmallWait(4)
+		ActionOverride("%Death_var%",ChangeAIScript("JO_FLYI",GENERAL))~
 				PATCH_PRINT ~Patching: %num_matches% matches found in %SOURCE_FILESPEC% for REPLACE_TEXTUALLY: %textToReplace%~
 				PATCH_PRINT ~... // %Death_var% : LeaveParty() found in %SOURCE_FILESPEC%
 				~

--- a/JOining_Party_Select/Lib/JOining_Party_Select_Cutscene.tph
+++ b/JOining_Party_Select/Lib/JOining_Party_Select_Cutscene.tph
@@ -85,12 +85,14 @@
 				PATCH_PRINT ~... // Dialog() found in %SOURCE_FILESPEC%
 				~
 			END
+// LeaveParty situation
 			SPRINT textToReplace ~^[%TAB% ]*LeaveParty()~
 			COUNT_REGEXP_INSTANCES ~%textToReplace%~ num_matches
 			PATCH_IF (num_matches > 0) BEGIN
 				REPLACE_TEXTUALLY CASE_INSENSITIVE ~%textToReplace%~ ~\0
 		SetGlobal("JO_Myself_LeaveParty","LOCALS",1)
-		Wait(4)~
+		SmallWait(4)
+		ChangeAIScript("JO_FLYI",GENERAL)~
 				PATCH_PRINT ~Patching: %num_matches% matches found in %SOURCE_FILESPEC% for REPLACE_TEXTUALLY: %textToReplace%~
 				PATCH_PRINT ~... // LeaveParty() found in %SOURCE_FILESPEC%
 				~
@@ -128,12 +130,14 @@ COPY_EXISTING_REGEXP GLOB ~^.+\.dlg$~ ~override~
 				PATCH_PRINT ~... // EndCutSceneMode() found in %SOURCE_FILESPEC%
 				~
 			END
+// LeaveParty situation
 			SPRINT textToReplace ~^[%TAB% ]*LeaveParty()~
 			COUNT_REGEXP_INSTANCES ~%textToReplace%~ num_matches
 			PATCH_IF (num_matches > 0) BEGIN
 				REPLACE_TEXTUALLY CASE_INSENSITIVE ~%textToReplace%~ ~\0
 		SetGlobal("JO_Myself_LeaveParty","LOCALS",1)
-		Wait(4)~
+		SmallWait(4)
+		ChangeAIScript("JO_FLYI",GENERAL)~
 				PATCH_PRINT ~Patching: %num_matches% matches found in %SOURCE_FILESPEC% for REPLACE_TEXTUALLY: %textToReplace%~
 				PATCH_PRINT ~... // LeaveParty() found in %SOURCE_FILESPEC%
 				~

--- a/JOining_Party_Select/Lib/JOining_Party_Select_DLG.tph
+++ b/JOining_Party_Select/Lib/JOining_Party_Select_DLG.tph
@@ -535,7 +535,8 @@ BEGIN
 			PATCH_IF (num_matches > 0) BEGIN
 				REPLACE_TEXTUALLY CASE_INSENSITIVE ~%textToReplace%~ ~\0
 		SetGlobal("JO_%Death_var%_LeaveParty","GLOBAL",1)
-		Wait(4)~
+		SmallWait(4)
+		ActionOverride("%Death_var%",ChangeAIScript("JO_FLYI",GENERAL))~
 				PATCH_PRINT ~Patching: %num_matches% matches found in %SOURCE_FILESPEC% for REPLACE_TEXTUALLY: %textToReplace%~
 				PATCH_PRINT ~... // %Death_var% : LeaveParty() found in %SOURCE_FILESPEC%
 				~


### PR DESCRIPTION
Salut !

La transition c'est toujours une galère...

Du coup je vais essayer une nouvelle méthode, cette pull request n'a pas vocation à être mergé, en tout cas pas en l'état.

Ce n'est pas du tout testé non plus.

Objectif : En corrélation avec `JO_%Death_var%_LeaveParty` et `Global("JO_Myself_LeaveParty","LOCALS",1)` changer le script "GENERAL" en JO_FLYI.baf afin que ses blocs s’exécutent au plus vite.

Si au niveau des variables à remettre à zero, tu vois un truc qui cloche ou si tu as des commentaires, n'hésites pas.

PS: Il y a aussi la possibilité de ne pas faire d'Imoen un familier, afin d'éviter de se prendre la tête avec ses particularités ou avec le mod ImoenForever de Jastey.

DoublePS : Changement de la ligne problématique avec VerbalConstant.
-  https://github.com/11jo/JOining_Party/issues/19