### PR TITLE
Dev loading switch

### DIFF
--- a/JOining_Party_Select/Baf/All_In.BAF
+++ b/JOining_Party_Select/Baf/All_In.BAF
@@ -11,36 +11,6 @@
 
 // For Party member After Main Loading Switch 1 //
 
-IF // One party member have to make room for traveler Loading Switch if the party is full
-//
-	Global("JO_JOIN_LOADING","GLOBAL",1)
-	Global("JO_JOIN_LOAD_PARTY_WAIT","GLOBAL",0) // Set to 1 by the first travelers switch
-	!TriggerOverride(Player1,GlobalGT("JO_JOIN_LOADING_PLAYER","LOCALS",0)) // Check if another party member is already leaving
-//
-	NumInPartyGT(5)
-	TriggerOverride(PartySlot6,Global("JO_JOIN_LOAD","LOCALS",0)) // Not a traveler switching at loading
-	!TriggerOverride(PartySlot6,Global("JO_JOINI","LOCALS",1)) // Not a traveler switching at loading
-	TriggerOverride(PartySlot6,Global("JO_Myself_InParty","LOCALS",1)) // Not a dead party member
-//
-	!TriggerOverride(PartySlot6,InPartySlot(Myself,0))
-THEN
-	RESPONSE #30
-		ActionOverride(Player1,IncrementGlobal("JO_JOIN_LOADING_PLAYER","LOCALS",1))
-		ActionOverride(PartySlot6,SetGlobal("JO_JOIN_LOADING_PLAYER","LOCALS",1))
-		ActionOverride(PartySlot6,DisplayStringHead(Myself,~Oh no ! More Travelers...~))
-		ActionOverride(PartySlot6,LeaveParty())
-		ActionOverride(PartySlot6,Deactivate(Myself))
-		Continue()
-	RESPONSE #20
-		NoAction()
-	RESPONSE #20
-		NoAction()
-	RESPONSE #20
-		NoAction()
-	RESPONSE #10
-		NoAction()
-END
-
 IF
 	Global("JO_JOIN_LOADING","GLOBAL",1)
 	Global("JO_JOIN_LOAD","LOCALS",0)

--- a/JOining_Party_Select/Baf/JO_JOIN/JO_JOIN.BAF
+++ b/JOining_Party_Select/Baf/JO_JOIN/JO_JOIN.BAF
@@ -12,32 +12,11 @@ IF
 THEN
 	RESPONSE #100
 		SetInterrupt(FALSE)
-		SetGlobal("JO_JOIN_CLEAR","LOCALS",2)
 		DisplayStringHead(Myself,~Yeah.~)
-		SetInterrupt(TRUE)
-		Continue() // Go to Yeah End
-END
-
-///////////////////////////////////////////////////////////////////////////////
-
-// JO_JOINX
-
-///////////////////////////////////////////////////////////////////////////////
-
-// Yeah End (End Switch between familiar and party)
-
-IF
-	OR(3)
-		Allegiance(Myself,FAMILIAR)
-		Allegiance(Myself,CONTROLLED)
-		!Global("JO_JOIN_IS_TRAVELER","LOCALS",0)
-	Global("JO_JOIN_CLEAR","LOCALS",2)
-THEN
-	RESPONSE #100
-		ChangeAIScript("JO_JOINX",RACE)// Go to JO_JOINX (ScriptAction / XP)
 		SetGlobal("JO_JOIN_CLEAR","LOCALS",3)
+		ChangeAIScript("JO_JOINX",RACE)// Go to JO_JOINX (ScriptAction / XP)
+		SetInterrupt(TRUE)
 END
-
 
 ///////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////

--- a/JOining_Party_Select/Baf/JO_JOINI.BAF
+++ b/JOining_Party_Select/Baf/JO_JOINI.BAF
@@ -811,9 +811,9 @@ THEN
 		SetGlobal("JO_JOINI","LOCALS",1)
 		SetGlobal("JO_JOIN_CLEAR","LOCALS",1) // ScriptAction All_in_Baf
 		EquipItemEx("JOMINHP1",1)
-		SmallWait(1)
+		// SmallWait(1)
 		DestroyItem("JOMINHP1")
-		SmallWait(1)
+		// SmallWait(1)
 		DisplayStringHead(Myself,~Hey.~)
 		SetInterrupt(TRUE)
 		JoinPartyOverride() // Go to All_In_Baf Switch between familiar and party

--- a/JOining_Party_Select/Baf/Join_ability/JO_JOINP.baf
+++ b/JOining_Party_Select/Baf/Join_ability/JO_JOINP.baf
@@ -38,9 +38,10 @@ IF
 	OR(2)
 		OnCreation()
 		Global("JO_JOIN_FORCE_LOAD","GLOBAL",1) // Force Loading Switch
-	OR(2)
+	OR(3)
 		!Global("JO_JOIN_AREA","MYAREA",1)  // Current area IS'NT a master area
-		See([ENEMY])
+		ActuallyInCombat()
+		Detect([ENEMY])
 // Dev
 	!Global("JO_JOIN_BLOP","GLOBAL",1) // Dev test for no master area
 // 
@@ -85,8 +86,11 @@ IF
 		Global("JO_JOIN_AREA","MYAREA",1) // Current area is a master area
 		Global("JO_JOIN_BLOP","GLOBAL",1) // Dev test for no master area
 	OR(2)
-		!See([ENEMY])
-		Global("JO_JOIN_BLOP","GLOBAL",1) // Dev test for See([ENEMY])
+		!ActuallyInCombat()
+		Global("JO_JOIN_BLOP","GLOBAL",1) // Dev test for ActuallyInCombat()
+	OR(2)
+		!Detect([ENEMY])
+		Global("JO_JOIN_BLOP","GLOBAL",1) // Dev test for Detect([ENEMY])
 // 
 	!Global("JO_JOIN_TRAVELER_NumInParty","GLOBAL",0) // Should prevent Loading switch if no traveler exists
 THEN

--- a/JOining_Party_Select/Baf/Join_ability/JO_LOAD_JO_JOINL.baf
+++ b/JOining_Party_Select/Baf/Join_ability/JO_LOAD_JO_JOINL.baf
@@ -60,6 +60,21 @@ THEN
 END
 */
 
+
+IF // One party member have to make room for traveler Loading Switch if the party is full
+	Global("JO_JOIN_LOADING_PLAYER","LOCALS",0) // check only if the sixth party member is currently in party
+	Global("JO_JOIN_LOAD_PARTY_WAIT","GLOBAL",0) // Set to 1 by the first travelers switch
+	Global("JO_JOIN_LOADING","GLOBAL",1)
+	NumInPartyGT(5)
+THEN
+	RESPONSE #100
+		IncrementGlobal("JO_JOIN_LOADING_PLAYER","LOCALS",1)
+		ActionOverride(PartySlot6,SetGlobal("JO_JOIN_LOADING_PLAYER","LOCALS",1))
+		ActionOverride(PartySlot6,DisplayStringHead(Myself,~Oh no ! More Travelers...~))
+		ActionOverride(PartySlot6,LeaveParty())
+		ActionOverride(PartySlot6,Deactivate(Myself))
+END
+
 IF
 	Delay(1)
 	Global("JO_JOIN_LOAD","LOCALS",1)

--- a/JOining_Party_Select/Baf/Join_ability/JO_LOAD_JO_JOINL.baf
+++ b/JOining_Party_Select/Baf/Join_ability/JO_LOAD_JO_JOINL.baf
@@ -10,6 +10,7 @@
 
 IF
 	Global("JO_JOIN_LOADING_PLAYER","LOCALS",0) // check only if the sixth party member is currently in party
+	Global("JO_JOIN_LOADING","GLOBAL",1)
 	NumInPartyGT(5)
 	OR(2)
 		StateCheck(PartySlot6,STATE_DEAD)
@@ -26,6 +27,7 @@ END
 
 IF // If Charname is PartySlot6.
 	Global("JO_JOIN_LOADING_PLAYER","LOCALS",0) // check only if the sixth party member is currently in party
+	Global("JO_JOIN_LOADING","GLOBAL",1)
 	NumInPartyGT(5)
 	InPartySlot(PartySlot6,0) // Charname is PartySlot6
 THEN


### PR DESCRIPTION
* extension des checks pour savoir si un combat est en cours pour se tp dans la room si besoin (je crains les effets imprévisibles que pourrait avoir la mort d'un personnage pendant un switch)
* retrait des SmallWait avant le Hey. pour limiter les risques et gagner un peu de temps
* fusion des deux blocs de JO_JOIN pour activer JO_JOINX en un cycle au lieu de deux
* déplacement du bloc pour désactiver slot6 dans le script du Player1, plus fiable et plus logique

