### PR TITLE
Add JO_JOIN_NOINDEPANDANCE ; update dialogue

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,6 +179,7 @@
 | JO_JOIN_QUICK_JOIN_TIMER | L | | n/a
 | JO_JOIN_NOPRIVACY | G | | 0: False<br>Other: True |
 | JO_JOIN_PRIVACY | L | Automatically deactive travelers if Charname is in another area of the party | 0: False<br>Other: True
+| JO_JOIN_NOINDEPANDANCE | G | If set, independance process is inactive | 0: False<br>Other: True |
 | JO_JOIN_INDEPANDANCE | L | Deactive travelers if Charname is separate from the party but in the same area | 0: inactive<br>3: 30 feet<br>5: 5 feet<br>8: 80 feet<br>10: 100 feet
 | JO_JOIN_NEED_INDEPANDANT | L | Desired value for `JO_JOIN_INDEPANDANCE` | 0: inactive<br>3: 30 feet<br>5: 5 feet<br>8: 80 feet<br>10: 100 feet
 | JO_JOIN_IS_INDEPANDANT | L | Set if the traveler is Deactivate by INDEPANDANCE process | 0: False<br>Other: True

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,6 +185,7 @@
 | JO_JOIN_INDEPANDANCE | L | Deactive travelers if Charname is separate from the party but in the same area | 0: inactive<br>3: 30 feet<br>5: 5 feet<br>8: 80 feet<br>10: 100 feet
 | JO_JOIN_NEED_INDEPANDANT | L | Desired value for `JO_JOIN_INDEPANDANCE` | 0: inactive<br>3: 30 feet<br>5: 5 feet<br>8: 80 feet<br>10: 100 feet
 | JO_JOIN_IS_INDEPANDANT | L | Set if the traveler is Deactivate by INDEPANDANCE process | 0: False<br>Other: True
+| JO_JOIN_NO_FILL_PARTY | G | Active fill party | process | 0: False<br>Other: True
 | JO_JOIN_FILL_PARTY | L | Allow traveler to join the group properly and automatically if free slots are available | 0: False<br>1: work in progress<br>2: end
 | JO_JOIN_NEVER_FILL | L | Prevent traveler to join the group properly and automatically if free slots are available | 0: False<br>Other: True |
 | JO_JOIN_FORCE_FILL_PARTY | L | Force the traveler to join the group | 0: False<br>Other: True |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,7 +154,7 @@
 | JO_JOIN_BD0120_xx | A | Specific to Korlaz donjon, used to keep traveler xx along. | 0: False<br>Other: True |
 | JO_JOIN_Move_Around | G | Charname general dialog set different number to make all current traveler reaction at once | 0: No action<br>value: current `value` dialog option is active |
 | JO_JOIN_Move_Done | L | Related to `JO_JOIN_Move_Around` used to make the script apply only once until next command | 0: False<br>Other: True
-| JO_JOIN_NO_SWITCHING_PARTY | G | Active party switching | 0: False<br>Other: True
+| JO_JOIN_NO_SWITCH_PARTY | G | Active party switching | 0: False<br>Other: True
 | JO_JOIN_SWITCHING_PARTY | G | Party switching step | 0: inactive<br>1: is starting<br>2: target found<br>3: switching
 | JO_JOIN_SWITCH_TIMER | L | Timer for Switching party between traveler and party member. | n/a |
 | JO_JOIN_READY_TO_SWITCH | L | Is active when a party member or a traveler is available to switch. | 0: False<br>1: Ready to switch<br>2: Conditions are clear<br>3: Im the party member who switch

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,6 +154,7 @@
 | JO_JOIN_BD0120_xx | A | Specific to Korlaz donjon, used to keep traveler xx along. | 0: False<br>Other: True |
 | JO_JOIN_Move_Around | G | Charname general dialog set different number to make all current traveler reaction at once | 0: No action<br>value: current `value` dialog option is active |
 | JO_JOIN_Move_Done | L | Related to `JO_JOIN_Move_Around` used to make the script apply only once until next command | 0: False<br>Other: True
+| JO_JOIN_NO_SWITCHING_PARTY | G | Active party switching | 0: False<br>Other: True
 | JO_JOIN_SWITCHING_PARTY | G | Party switching step | 0: inactive<br>1: is starting<br>2: target found<br>3: switching
 | JO_JOIN_SWITCH_TIMER | L | Timer for Switching party between traveler and party member. | n/a |
 | JO_JOIN_READY_TO_SWITCH | L | Is active when a party member or a traveler is available to switch. | 0: False<br>1: Ready to switch<br>2: Conditions are clear<br>3: Im the party member who switch

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -175,6 +175,7 @@
 | JO_JOIN_LOADING_MAX | L | | Number of traveler autorised to switch at the same time | 1: 1 traveler<br>2:  2 travelers<br>3:  3 travelers<br>
 | JO_JOIN_FORCE_LOAD | G | Force the Loading Switch at will | 0: False<br>Other: True
 | JO_JOIN_PS_SAFE_SLOT | G | Protect some party slot to switching party | 1: Slot1 only<br>2: Slot1 & 2<br>3: Slot1 to 3<br>4: Slot1 to 4<br>5: Slot1 to 5<br>6+: All slots<br>Other: All slot are available
+| JO_JOIN_NO_QUICK_SWITCH | G | Active quick switch | 0: False<br>Other: True |
 | JO_JOIN_QUICK_SWITCH | L | |
 | JO_JOIN_QUICK_NEVER_JOIN | L | Temporarly prevent travelers to switch or join the group | 0: False<br>Other: True
 | JO_JOIN_QUICK_JOIN_TIMER | L | | n/a

--- a/JOining_Party_Select/Baf/JO_JOINI.BAF
+++ b/JOining_Party_Select/Baf/JO_JOINI.BAF
@@ -231,7 +231,9 @@ END
 IF
 	Global("JO_JOIN_CUTSCENE","GLOBAL",0) // Don't reactivate if cutscene is in motion
 	!Global("JO_JOIN_IS_INDEPANDANT","LOCALS",0)
-	Global("JO_JOIN_INDEPANDANCE","LOCALS",0)
+	OR(2)
+		Global("JO_JOIN_INDEPANDANCE","LOCALS",0)
+		!Global("JO_JOIN_NOINDEPANDANCE","GLOBAL",0)
 THEN
 	RESPONSE #100
 		Activate(Myself)
@@ -242,6 +244,7 @@ END
 IF // Range 100
 //
 	!AreaCheck("JO2608")
+	Global("JO_JOIN_NOINDEPANDANCE","GLOBAL",0)
 	Global("JO_JOIN_LOADING_SWITCH","GLOBAL",0)
 	NumInPartyAliveGT(1)
 	Global("JO_JOIN_INDEPANDANCE","LOCALS",10) // Set in PID
@@ -279,6 +282,7 @@ END
 IF // Range 80
 //
 	!AreaCheck("JO2608")
+	Global("JO_JOIN_NOINDEPANDANCE","GLOBAL",0)
 	Global("JO_JOIN_LOADING_SWITCH","GLOBAL",0)
 	NumInPartyAliveGT(1)
 	Global("JO_JOIN_INDEPANDANCE","LOCALS",8) // Set in PID
@@ -316,6 +320,7 @@ END
 IF // Range 50
 //
 	!AreaCheck("JO2608")
+	Global("JO_JOIN_NOINDEPANDANCE","GLOBAL",0)
 	Global("JO_JOIN_LOADING_SWITCH","GLOBAL",0)
 	NumInPartyAliveGT(1)
 	Global("JO_JOIN_INDEPANDANCE","LOCALS",5) // Set in PID
@@ -353,6 +358,7 @@ END
 IF // Range 30
 //
 	!AreaCheck("JO2608")
+	Global("JO_JOIN_NOINDEPANDANCE","GLOBAL",0)
 	Global("JO_JOIN_LOADING_SWITCH","GLOBAL",0)
 	NumInPartyAliveGT(1)
 	Global("JO_JOIN_INDEPANDANCE","LOCALS",3) // Set in PID

--- a/JOining_Party_Select/Baf/JO_JOINI.BAF
+++ b/JOining_Party_Select/Baf/JO_JOINI.BAF
@@ -730,6 +730,7 @@ IF // Block wait 2 for Quick Switch // Return to Main Quick Switch 1 if another 
 //
 	Global("JO_JOIN_AREA_TRANSITION","GLOBAL",1) 
 //
+	Global("JO_JOIN_NO_QUICK_SWITCH","GLOBAL",0) // Quick switch is active
 	Global("JO_JOIN_LOADING_SWITCH","GLOBAL",0) // Don't use this block at loading
 	Global("JO_JOIN_RETURN_SLOT","GLOBAL",0)
 	OR(4)
@@ -752,6 +753,7 @@ END
 // Main Quick Switch 2
 
 IF
+	Global("JO_JOIN_NO_QUICK_SWITCH","GLOBAL",0) // Quick switch is active
 	OR(2)
 		Global("JO_JOIN_QUICK_FORCE_JOIN","LOCALS",1) // Set by JO_JOIN_Move_Around
 		Delay(20)

--- a/JOining_Party_Select/Baf/JO_JOINI.BAF
+++ b/JOining_Party_Select/Baf/JO_JOINI.BAF
@@ -2465,7 +2465,7 @@ END
 // Main Switching Party 1
 
 IF // First check
-	Global("JO_JOIN_NO_SWITCHING_PARTY","GLOBAL",0) // Switching party is active
+	Global("JO_JOIN_NO_SWITCH_PARTY","GLOBAL",0) // Switching party is active
 	Global("JO_JOIN_SWITCHING_PARTY","GLOBAL",0) // Switching party step 0
 	Global("JO_JOIN_READY_TO_SWITCH","LOCALS",1)
 	Global("JO_JOIN_LEAVING_PARTY","GLOBAL",0)
@@ -2536,7 +2536,7 @@ THEN
 END
 
 IF // No slot found because they are safe or members are not wannabe
-	Global("JO_JOIN_NO_SWITCHING_PARTY","GLOBAL",0) // Switching party is active
+	Global("JO_JOIN_NO_SWITCH_PARTY","GLOBAL",0) // Switching party is active
 	Global("JO_JOIN_SWITCHING_PARTY","GLOBAL",0) // Switching party step 0
 	Global("JO_JOIN_READY_TO_SWITCH","LOCALS",1)
 // Global checks

--- a/JOining_Party_Select/Baf/JO_JOINI.BAF
+++ b/JOining_Party_Select/Baf/JO_JOINI.BAF
@@ -2845,6 +2845,7 @@ END
 IF
 //
 	Global("JO_JOIN_AREA_TRANSITION","GLOBAL",0)
+	Global("JO_JOIN_NO_FILL_PARTY","GLOBAL",0) // Fill party is active
 //
 	Global("JO_JOIN_LOADING_SWITCH","GLOBAL",0) // Don't use this block at loading
 	Global("JO_JOIN_RETURN_SLOT","GLOBAL",0)

--- a/JOining_Party_Select/Baf/JO_JOINI.BAF
+++ b/JOining_Party_Select/Baf/JO_JOINI.BAF
@@ -2463,6 +2463,7 @@ END
 // Main Switching Party 1
 
 IF // First check
+	Global("JO_JOIN_NO_SWITCHING_PARTY","GLOBAL",0) // Switching party is active
 	Global("JO_JOIN_SWITCHING_PARTY","GLOBAL",0) // Switching party step 0
 	Global("JO_JOIN_READY_TO_SWITCH","LOCALS",1)
 	Global("JO_JOIN_LEAVING_PARTY","GLOBAL",0)
@@ -2533,6 +2534,7 @@ THEN
 END
 
 IF // No slot found because they are safe or members are not wannabe
+	Global("JO_JOIN_NO_SWITCHING_PARTY","GLOBAL",0) // Switching party is active
 	Global("JO_JOIN_SWITCHING_PARTY","GLOBAL",0) // Switching party step 0
 	Global("JO_JOIN_READY_TO_SWITCH","LOCALS",1)
 // Global checks

--- a/JOining_Party_Select/Baf/JO_JOINI.BAF
+++ b/JOining_Party_Select/Baf/JO_JOINI.BAF
@@ -2845,7 +2845,9 @@ END
 IF
 //
 	Global("JO_JOIN_AREA_TRANSITION","GLOBAL",0)
-	Global("JO_JOIN_NO_FILL_PARTY","GLOBAL",0) // Fill party is active
+	OR(2)
+		Global("JO_JOIN_NO_FILL_PARTY","GLOBAL",0) // Fill party is active
+		!Global("JO_JOIN_FORCE_FILL_PARTY","LOCALS",0)
 //
 	Global("JO_JOIN_LOADING_SWITCH","GLOBAL",0) // Don't use this block at loading
 	Global("JO_JOIN_RETURN_SLOT","GLOBAL",0)

--- a/JOining_Party_Select/D/All_In.D
+++ b/JOining_Party_Select/D/All_In.D
@@ -140,11 +140,7 @@ StartDialogueNoSet(Player6)~ EXIT
 		SetGlobal("JO_JOIN_IS_JOINING","LOCALS",1)~ GOTO JO_JOINYes //
 
 // Indepandance
-	IF ~IsGabber(Player1) !Global("JO_JOIN_NEED_INDEPANDANT","LOCALS",3)~ THEN REPLY ~^0xFF5b5b5bI am pretty independant, don't follow me when I walk 30 steps away from the group !^-~ DO ~SetGlobal("JO_JOIN_NEED_INDEPANDANT","LOCALS",3)~ GOTO JO_JOINYes //
-	IF ~IsGabber(Player1) !Global("JO_JOIN_NEED_INDEPANDANT","LOCALS",5)~ THEN REPLY ~^0xFF5b5b5bI am pretty independant, don't follow me when I walk 50 steps away from the group !^-~ DO ~SetGlobal("JO_JOIN_NEED_INDEPANDANT","LOCALS",5)~ GOTO JO_JOINYes //
-	IF ~IsGabber(Player1) !Global("JO_JOIN_NEED_INDEPANDANT","LOCALS",8)~ THEN REPLY ~^0xFF5b5b5bI am pretty independant, don't follow me when I walk 80 steps away from the group !^-~ DO ~SetGlobal("JO_JOIN_NEED_INDEPANDANT","LOCALS",8)~ GOTO JO_JOINYes //
-	IF ~IsGabber(Player1) !Global("JO_JOIN_NEED_INDEPANDANT","LOCALS",10)~ THEN REPLY ~^0xFF5b5b5bI am pretty independant, don't follow me when I walk 100 steps away from the group !^-~ DO ~SetGlobal("JO_JOIN_NEED_INDEPANDANT","LOCALS",10)~ GOTO JO_JOINYes //
-	IF ~IsGabber(Player1) !Global("JO_JOIN_NEED_INDEPANDANT","LOCALS",0)~ THEN REPLY ~^0xFF7f6000Follow me when I walk away from the group, better stick together.^-~ DO ~SetGlobal("JO_JOIN_NEED_INDEPANDANT","LOCALS",0)~ GOTO JO_JOINYes //
+	IF ~IsGabber(Player1)~ THEN REPLY ~Independance menu~ GOTO INDEPENDANCE
 
 // Indepandance for traveler // ChangeEnemyAlly
 
@@ -736,4 +732,16 @@ END
 
 ////////////////////////////////////////////////////
 
+	// Indepandance
+	IF ~~ THEN BEGIN INDEPENDANCE
+		SAY ~Independance with <GABBER>~
+		IF ~~ THEN REPLY ~Go back~ GOTO LEGION
+		IF ~!Global("JO_JOIN_NEED_INDEPANDANT","LOCALS",0)~ THEN REPLY ~^0xFF7f6000Follow me when I walk away from the group, better stick together.^-~ DO ~SetGlobal("JO_JOIN_NEED_INDEPANDANT","LOCALS",0)~ GOTO JO_JOINYes //
+		IF ~!Global("JO_JOIN_NEED_INDEPANDANT","LOCALS",3)~ THEN REPLY ~^0xFF5b5b5bI am pretty independant, don't follow me when I walk 30 steps away from the group !^-~ DO ~SetGlobal("JO_JOIN_NEED_INDEPANDANT","LOCALS",3)~ GOTO JO_JOINYes //
+		IF ~!Global("JO_JOIN_NEED_INDEPANDANT","LOCALS",5)~ THEN REPLY ~^0xFF5b5b5bI am pretty independant, don't follow me when I walk 50 steps away from the group !^-~ DO ~SetGlobal("JO_JOIN_NEED_INDEPANDANT","LOCALS",5)~ GOTO JO_JOINYes //
+		IF ~!Global("JO_JOIN_NEED_INDEPANDANT","LOCALS",8)~ THEN REPLY ~^0xFF5b5b5bI am pretty independant, don't follow me when I walk 80 steps away from the group !^-~ DO ~SetGlobal("JO_JOIN_NEED_INDEPANDANT","LOCALS",8)~ GOTO JO_JOINYes //
+		IF ~!Global("JO_JOIN_NEED_INDEPANDANT","LOCALS",10)~ THEN REPLY ~^0xFF5b5b5bI am pretty independant, don't follow me when I walk 100 steps away from the group !^-~ DO ~SetGlobal("JO_JOIN_NEED_INDEPANDANT","LOCALS",10)~ GOTO JO_JOINYes //
+	END
+
 END // APPEND
+

--- a/JOining_Party_Select/D/JOJOINNE.D
+++ b/JOining_Party_Select/D/JOJOINNE.D
@@ -60,38 +60,7 @@ IF ~True()~ THEN BEGIN 0
 	IF ~Global("JO_JOIN_Move_Around","GLOBAL",0)~ THEN REPLY ~^0xFFFF00FFTravelers, stay at this location.^-~ DO ~SetGlobal("JO_JOIN_Move_Around","GLOBAL",25)~ EXIT //
 
 // Free slots in party // Fill party
-	IF ~Global("JO_JOIN_Move_Around","GLOBAL",0)
-		NumInParty(5)
-		Global("JO_JOIN_LOADING_SWITCH","GLOBAL",0)
-		Global("JO_JOIN_SWITCHING_PARTY","GLOBAL",0)
-		Global("JO_JOIN_LEAVING_PARTY","GLOBAL",0)
-		Global("JO_NOJOIN","GLOBAL",0)
-		OR(2)
-			Global("JO_JOIN_AREA","MYAREA",1)
-			Global("JO_JOIN_BLOP","GLOBAL",1)
-		!Global("JO_JOIN_AREA_TRANSITION","GLOBAL",1)~ THEN REPLY ~^0xFF6aa84fThere is room for one traveler to Fill Party.^-~ DO ~SetGlobal("JO_JOIN_Move_Around","GLOBAL",15)~ EXIT //
-	IF ~Global("JO_JOIN_Move_Around","GLOBAL",0)
-		NumInParty(4)
-		Global("JO_JOIN_LOADING_SWITCH","GLOBAL",0)
-		Global("JO_JOIN_SWITCHING_PARTY","GLOBAL",0)
-		Global("JO_JOIN_LEAVING_PARTY","GLOBAL",0)
-		Global("JO_NOJOIN","GLOBAL",0)
-		OR(2)
-			Global("JO_JOIN_AREA","MYAREA",1)
-			Global("JO_JOIN_BLOP","GLOBAL",1)
-		!Global("JO_JOIN_AREA_TRANSITION","GLOBAL",1)~ THEN REPLY ~^0xFF6aa84fThere is room for two travelers to Fill Party.^-~ DO ~SetGlobal("JO_JOIN_Move_Around","GLOBAL",15)~ EXIT //
-	IF ~Global("JO_JOIN_Move_Around","GLOBAL",0)
-		NumInParty(3)
-		Global("JO_JOIN_LOADING_SWITCH","GLOBAL",0)
-		Global("JO_JOIN_SWITCHING_PARTY","GLOBAL",0)
-		Global("JO_JOIN_LEAVING_PARTY","GLOBAL",0)
-		Global("JO_NOJOIN","GLOBAL",0)
-		OR(2)
-			Global("JO_JOIN_AREA","MYAREA",1)
-			Global("JO_JOIN_BLOP","GLOBAL",1)
-		!Global("JO_JOIN_AREA_TRANSITION","GLOBAL",1)~ THEN REPLY ~^0xFF6aa84fThere is room for three travelers to Fill Party.^-~ DO ~SetGlobal("JO_JOIN_Move_Around","GLOBAL",15)~ EXIT //
-	IF ~Global("JO_JOIN_Move_Around","GLOBAL",0)~ THEN REPLY ~^0xFF16537eTravelers don't come in party when Fill Party.^-~ DO ~SetGlobal("JO_JOIN_Move_Around","GLOBAL",27)~ EXIT //
-	IF ~Global("JO_JOIN_Move_Around","GLOBAL",0)~ THEN REPLY ~^0xFF7f6000Travelers come in party when Fill Party.^-~ DO ~SetGlobal("JO_JOIN_Move_Around","GLOBAL",26)~ EXIT //
+	IF ~~ THEN REPLY ~Fill party menu~ GOTO FILL_PARTY
 
 // Switching party between travelers and party members
 	IF ~~ THEN REPLY ~Switch party menu~ GOTO SWITCH_PARTY
@@ -638,4 +607,49 @@ IF ~~ THEN BEGIN QUICK_SWITCH
 	IF ~Global("JO_JOIN_NO_QUICK_SWITCH","GLOBAL",0)
 		Global("JO_JOIN_BLOP","GLOBAL",0)
 		!Global("JO_JOIN_AREA_TRANSITION","GLOBAL",0)~ THEN REPLY ~Quick Switch isn't available here.~ EXIT //
+END
+
+
+// Fill party
+
+IF ~~ THEN BEGIN FILL_PARTY
+	SAY ~Fill party menu~
+	IF ~~ THEN REPLY ~Go back~ GOTO 0
+	IF ~Global("JO_JOIN_NO_FILL_PARTY","GLOBAL",0)~ THEN REPLY ~Deactive Fill party~ DO ~SetGlobal("JO_JOIN_NO_FILL_PARTY","GLOBAL",1)~ GOTO 0
+	IF ~!Global("JO_JOIN_NO_FILL_PARTY","GLOBAL",0)~ THEN REPLY ~^GActive Fill party^-~ DO ~SetGlobal("JO_JOIN_NO_FILL_PARTY","GLOBAL",0)~ GOTO 0
+	IF ~Global("JO_JOIN_NO_FILL_PARTY","GLOBAL",0)
+		Global("JO_JOIN_Move_Around","GLOBAL",0)
+		NumInParty(5)
+		Global("JO_JOIN_LOADING_SWITCH","GLOBAL",0)
+		Global("JO_JOIN_SWITCHING_PARTY","GLOBAL",0)
+		Global("JO_JOIN_LEAVING_PARTY","GLOBAL",0)
+		Global("JO_NOJOIN","GLOBAL",0)
+		OR(2)
+			!Global("JO_JOIN_AREA","MYAREA",0)
+			!Global("JO_JOIN_BLOP","GLOBAL",0)
+		Global("JO_JOIN_AREA_TRANSITION","GLOBAL",0)~ THEN REPLY ~^0xFF6aa84fThere is room for one traveler to Fill Party.^-~ DO ~SetGlobal("JO_JOIN_Move_Around","GLOBAL",15)~ EXIT //
+	IF ~Global("JO_JOIN_NO_FILL_PARTY","GLOBAL",0)
+		Global("JO_JOIN_Move_Around","GLOBAL",0)
+		NumInParty(4)
+		Global("JO_JOIN_LOADING_SWITCH","GLOBAL",0)
+		Global("JO_JOIN_SWITCHING_PARTY","GLOBAL",0)
+		Global("JO_JOIN_LEAVING_PARTY","GLOBAL",0)
+		Global("JO_NOJOIN","GLOBAL",0)
+		OR(2)
+			!Global("JO_JOIN_AREA","MYAREA",0)
+			!Global("JO_JOIN_BLOP","GLOBAL",0)
+		Global("JO_JOIN_AREA_TRANSITION","GLOBAL",0)~ THEN REPLY ~^0xFF6aa84fThere is room for two travelers to Fill Party.^-~ DO ~SetGlobal("JO_JOIN_Move_Around","GLOBAL",15)~ EXIT //
+	IF ~Global("JO_JOIN_NO_FILL_PARTY","GLOBAL",0)
+		Global("JO_JOIN_Move_Around","GLOBAL",0)
+		NumInParty(3)
+		Global("JO_JOIN_LOADING_SWITCH","GLOBAL",0)
+		Global("JO_JOIN_SWITCHING_PARTY","GLOBAL",0)
+		Global("JO_JOIN_LEAVING_PARTY","GLOBAL",0)
+		Global("JO_NOJOIN","GLOBAL",0)
+		OR(2)
+			!Global("JO_JOIN_AREA","MYAREA",0)
+			!Global("JO_JOIN_BLOP","GLOBAL",0)
+		Global("JO_JOIN_AREA_TRANSITION","GLOBAL",0)~ THEN REPLY ~^0xFF6aa84fThere is room for three travelers to Fill Party.^-~ DO ~SetGlobal("JO_JOIN_Move_Around","GLOBAL",15)~ EXIT //
+	IF ~Global("JO_JOIN_NO_FILL_PARTY","GLOBAL",0) Global("JO_JOIN_Move_Around","GLOBAL",0)~ THEN REPLY ~^0xFF16537eTravelers don't come in party when Fill Party.^-~ DO ~SetGlobal("JO_JOIN_Move_Around","GLOBAL",27)~ EXIT //
+	IF ~Global("JO_JOIN_NO_FILL_PARTY","GLOBAL",0) Global("JO_JOIN_Move_Around","GLOBAL",0)~ THEN REPLY ~^0xFF7f6000Travelers come in party when Fill Party.^-~ DO ~SetGlobal("JO_JOIN_Move_Around","GLOBAL",26)~ EXIT //
 END

--- a/JOining_Party_Select/D/JOJOINNE.D
+++ b/JOining_Party_Select/D/JOJOINNE.D
@@ -608,16 +608,16 @@ END
 IF ~~ THEN BEGIN SWITCH_PARTY
 	SAY ~Switch party menu~
 	IF ~~ THEN REPLY ~Go back~ GOTO 0
-	IF ~Global("JO_JOIN_NO_SWITCHING_PARTY","GLOBAL",0)~ THEN REPLY ~Deactive Switch party~ DO ~SetGlobal("JO_JOIN_NO_SWITCHING_PARTY","GLOBAL",1)~ GOTO 0
-	IF ~!Global("JO_JOIN_NO_SWITCHING_PARTY","GLOBAL",0)~ THEN REPLY ~^GActive Switch party^-~ DO ~SetGlobal("JO_JOIN_NO_SWITCHING_PARTY","GLOBAL",0)~ GOTO 0
-	IF ~Global("JO_JOIN_NO_SWITCHING_PARTY","GLOBAL",0) Global("JO_JOIN_Move_Around","GLOBAL",0)~ THEN REPLY ~^0xFF5b5b5bTravelers stop switching places with party members.^-~ DO ~SetGlobal("JO_JOIN_Move_Around","GLOBAL",10)~ EXIT //
-	IF ~Global("JO_JOIN_NO_SWITCHING_PARTY","GLOBAL",0) Global("JO_JOIN_Move_Around","GLOBAL",0)~ THEN REPLY ~^0xFF7f6000Travelers if party members are available you can switch places.^-~ DO ~SetGlobal("JO_JOIN_Move_Around","GLOBAL",11)~ EXIT //
-	IF ~Global("JO_JOIN_NO_SWITCHING_PARTY","GLOBAL",0) !Global("JO_JOIN_PS_SAFE_SLOT","GLOBAL",0)~ THEN REPLY ~^0xFF6aa84fTravelers you can switch places with every party members !^-~ DO ~SetGlobal("JO_JOIN_PS_SAFE_SLOT","GLOBAL",0)~ EXIT //
-	IF ~Global("JO_JOIN_NO_SWITCHING_PARTY","GLOBAL",0) !Global("JO_JOIN_PS_SAFE_SLOT","GLOBAL",3)~ THEN REPLY ~^0xFF16537eTravelers you can switch places only with the last three party member !^-~ DO ~SetGlobal("JO_JOIN_PS_SAFE_SLOT","GLOBAL",3)~ EXIT //
-	IF ~Global("JO_JOIN_NO_SWITCHING_PARTY","GLOBAL",0) !Global("JO_JOIN_PS_SAFE_SLOT","GLOBAL",4)~ THEN REPLY ~^0xFF16537eTravelers you can switch places only with the last two party member !^-~ DO ~SetGlobal("JO_JOIN_PS_SAFE_SLOT","GLOBAL",4)~ EXIT //
-	IF ~Global("JO_JOIN_NO_SWITCHING_PARTY","GLOBAL",0) !Global("JO_JOIN_PS_SAFE_SLOT","GLOBAL",5)~ THEN REPLY ~^0xFF16537eTravelers you can switch places only with the last party member !^-~ DO ~SetGlobal("JO_JOIN_PS_SAFE_SLOT","GLOBAL",5)~ EXIT //
-	IF ~Global("JO_JOIN_NO_SWITCHING_PARTY","GLOBAL",0) Global("JO_JOIN_Move_Around","GLOBAL",0)~ THEN REPLY ~^0xFF5b5b5bParty members stop switching places with travelers.^-~ DO ~SetGlobal("JO_JOIN_Move_Around","GLOBAL",28)~ EXIT //
-	IF ~Global("JO_JOIN_NO_SWITCHING_PARTY","GLOBAL",0) Global("JO_JOIN_Move_Around","GLOBAL",0)~ THEN REPLY ~^0xFF7f6000Party members if travelers are available you can switch places.^-~ DO ~SetGlobal("JO_JOIN_Move_Around","GLOBAL",29)~ EXIT //
+	IF ~Global("JO_JOIN_NO_SWITCH_PARTY","GLOBAL",0)~ THEN REPLY ~Deactive Switch party~ DO ~SetGlobal("JO_JOIN_NO_SWITCH_PARTY","GLOBAL",1)~ GOTO 0
+	IF ~!Global("JO_JOIN_NO_SWITCH_PARTY","GLOBAL",0)~ THEN REPLY ~^GActive Switch party^-~ DO ~SetGlobal("JO_JOIN_NO_SWITCH_PARTY","GLOBAL",0)~ GOTO 0
+	IF ~Global("JO_JOIN_NO_SWITCH_PARTY","GLOBAL",0) Global("JO_JOIN_Move_Around","GLOBAL",0)~ THEN REPLY ~^0xFF5b5b5bTravelers stop switching places with party members.^-~ DO ~SetGlobal("JO_JOIN_Move_Around","GLOBAL",10)~ EXIT //
+	IF ~Global("JO_JOIN_NO_SWITCH_PARTY","GLOBAL",0) Global("JO_JOIN_Move_Around","GLOBAL",0)~ THEN REPLY ~^0xFF7f6000Travelers if party members are available you can switch places.^-~ DO ~SetGlobal("JO_JOIN_Move_Around","GLOBAL",11)~ EXIT //
+	IF ~Global("JO_JOIN_NO_SWITCH_PARTY","GLOBAL",0) !Global("JO_JOIN_PS_SAFE_SLOT","GLOBAL",0)~ THEN REPLY ~^0xFF6aa84fTravelers you can switch places with every party members !^-~ DO ~SetGlobal("JO_JOIN_PS_SAFE_SLOT","GLOBAL",0)~ EXIT //
+	IF ~Global("JO_JOIN_NO_SWITCH_PARTY","GLOBAL",0) !Global("JO_JOIN_PS_SAFE_SLOT","GLOBAL",3)~ THEN REPLY ~^0xFF16537eTravelers you can switch places only with the last three party member !^-~ DO ~SetGlobal("JO_JOIN_PS_SAFE_SLOT","GLOBAL",3)~ EXIT //
+	IF ~Global("JO_JOIN_NO_SWITCH_PARTY","GLOBAL",0) !Global("JO_JOIN_PS_SAFE_SLOT","GLOBAL",4)~ THEN REPLY ~^0xFF16537eTravelers you can switch places only with the last two party member !^-~ DO ~SetGlobal("JO_JOIN_PS_SAFE_SLOT","GLOBAL",4)~ EXIT //
+	IF ~Global("JO_JOIN_NO_SWITCH_PARTY","GLOBAL",0) !Global("JO_JOIN_PS_SAFE_SLOT","GLOBAL",5)~ THEN REPLY ~^0xFF16537eTravelers you can switch places only with the last party member !^-~ DO ~SetGlobal("JO_JOIN_PS_SAFE_SLOT","GLOBAL",5)~ EXIT //
+	IF ~Global("JO_JOIN_NO_SWITCH_PARTY","GLOBAL",0) Global("JO_JOIN_Move_Around","GLOBAL",0)~ THEN REPLY ~^0xFF5b5b5bParty members stop switching places with travelers.^-~ DO ~SetGlobal("JO_JOIN_Move_Around","GLOBAL",28)~ EXIT //
+	IF ~Global("JO_JOIN_NO_SWITCH_PARTY","GLOBAL",0) Global("JO_JOIN_Move_Around","GLOBAL",0)~ THEN REPLY ~^0xFF7f6000Party members if travelers are available you can switch places.^-~ DO ~SetGlobal("JO_JOIN_Move_Around","GLOBAL",29)~ EXIT //
 END
 
 // Quick switch

--- a/JOining_Party_Select/D/JOJOINNE.D
+++ b/JOining_Party_Select/D/JOJOINNE.D
@@ -54,11 +54,7 @@ IF ~True()~ THEN BEGIN 0
 	IF ~Global("JO_JOIN_NOPRIVACY","GLOBAL",0)~ THEN REPLY ~^0xFF82E6FFI am an open book, no need for privacy.^-~ DO ~SetGlobal("JO_JOIN_NOPRIVACY","GLOBAL",1)~ EXIT //
 
 // Indepandance
-	IF ~~ THEN REPLY ~^0xFF5b5b5bI am pretty independant, don't follow me when I walk 30 steps away from the group !^-~ DO ~SetGlobal("JO_JOIN_Move_Around","GLOBAL",19)~ EXIT //
-	IF ~~ THEN REPLY ~^0xFF5b5b5bI am pretty independant, don't follow me when I walk 50 steps away from the group !^-~ DO ~SetGlobal("JO_JOIN_Move_Around","GLOBAL",20)~ EXIT //
-	IF ~~ THEN REPLY ~^0xFF5b5b5bI am pretty independant, don't follow me when I walk 80 steps away from the group !^-~ DO ~SetGlobal("JO_JOIN_Move_Around","GLOBAL",21)~ EXIT //
-	IF ~~ THEN REPLY ~^0xFF5b5b5bI am pretty independant, don't follow me when I walk 100 steps away from the group !^-~ DO ~SetGlobal("JO_JOIN_Move_Around","GLOBAL",22)~ EXIT 
-	IF ~~ THEN REPLY ~^0xFF7f6000Follow me when I walk away from the group, better stick together.^-~ DO ~SetGlobal("JO_JOIN_Move_Around","GLOBAL",18)~ EXIT //
+	IF ~~ THEN REPLY ~Independance menu~ GOTO INDEPENDANCE
 
 // ChangeEnemyAlly
 /*
@@ -610,3 +606,15 @@ END
 
 ///////////////////////////////////////////////////////////////////////////////
 
+// Indepandance
+IF ~~ THEN BEGIN INDEPENDANCE
+	SAY ~Independance menu~
+	IF ~~ THEN REPLY ~Go back~ GOTO 0
+	IF ~Global("JO_JOIN_NOINDEPANDANCE","GLOBAL",0)~ THEN REPLY ~Deactive Independance~ DO ~SetGlobal("JO_JOIN_NOINDEPANDANCE","GLOBAL",1)~ GOTO 0
+	IF ~!Global("JO_JOIN_NOINDEPANDANCE","GLOBAL",0)~ THEN REPLY ~^GActive Independance^-~ DO ~SetGlobal("JO_JOIN_NOINDEPANDANCE","GLOBAL",0)~ GOTO 0
+	IF ~Global("JO_JOIN_NOINDEPANDANCE","GLOBAL",0)~ THEN REPLY ~^0xFF7f6000Follow me when I walk away from the group, better stick together.^-~ DO ~SetGlobal("JO_JOIN_Move_Around","GLOBAL",18)~ EXIT //
+	IF ~Global("JO_JOIN_NOINDEPANDANCE","GLOBAL",0)~ THEN REPLY ~^0xFF5b5b5bI am pretty independant, don't follow me when I walk 30 steps away from the group !^-~ DO ~SetGlobal("JO_JOIN_Move_Around","GLOBAL",19)~ EXIT //
+	IF ~Global("JO_JOIN_NOINDEPANDANCE","GLOBAL",0)~ THEN REPLY ~^0xFF5b5b5bI am pretty independant, don't follow me when I walk 50 steps away from the group !^-~ DO ~SetGlobal("JO_JOIN_Move_Around","GLOBAL",20)~ EXIT //
+	IF ~Global("JO_JOIN_NOINDEPANDANCE","GLOBAL",0)~ THEN REPLY ~^0xFF5b5b5bI am pretty independant, don't follow me when I walk 80 steps away from the group !^-~ DO ~SetGlobal("JO_JOIN_Move_Around","GLOBAL",21)~ EXIT //
+	IF ~Global("JO_JOIN_NOINDEPANDANCE","GLOBAL",0)~ THEN REPLY ~^0xFF5b5b5bI am pretty independant, don't follow me when I walk 100 steps away from the group !^-~ DO ~SetGlobal("JO_JOIN_Move_Around","GLOBAL",22)~ EXIT 
+END

--- a/JOining_Party_Select/D/JOJOINNE.D
+++ b/JOining_Party_Select/D/JOJOINNE.D
@@ -103,13 +103,7 @@ IF ~True()~ THEN BEGIN 0
 	IF ~Global("JO_JOIN_Move_Around","GLOBAL",0)~ THEN REPLY ~^0xFF7f6000Travelers come in party when Fill Party.^-~ DO ~SetGlobal("JO_JOIN_Move_Around","GLOBAL",26)~ EXIT //
 
 // Switching party between travelers and party members
-	IF ~Global("JO_JOIN_Move_Around","GLOBAL",0)~ THEN REPLY ~^0xFF5b5b5bTravelers stop switching places with party members.^-~ DO ~SetGlobal("JO_JOIN_Move_Around","GLOBAL",10)~ EXIT //
-	IF ~Global("JO_JOIN_Move_Around","GLOBAL",0)~ THEN REPLY ~^0xFF7f6000Travelers if party members are available you can switch places.^-~ DO ~SetGlobal("JO_JOIN_Move_Around","GLOBAL",11)~ EXIT //
-	IF ~!Global("JO_JOIN_PS_SAFE_SLOT","GLOBAL",3)~ THEN REPLY ~^0xFF16537eTravelers you can switch places only with the last three party member !^-~ DO ~SetGlobal("JO_JOIN_PS_SAFE_SLOT","GLOBAL",3)~ EXIT //
-	IF ~!Global("JO_JOIN_PS_SAFE_SLOT","GLOBAL",0)~ THEN REPLY ~^0xFF6aa84fTravelers you can switch places with every party members !^-~ DO ~SetGlobal("JO_JOIN_PS_SAFE_SLOT","GLOBAL",0)~ EXIT //
-	IF ~Global("JO_JOIN_Move_Around","GLOBAL",0)~ THEN REPLY ~^0xFF5b5b5bParty members stop switching places with travelers.^-~ DO ~SetGlobal("JO_JOIN_Move_Around","GLOBAL",28)~ EXIT //
-	IF ~Global("JO_JOIN_Move_Around","GLOBAL",0)~ THEN REPLY ~^0xFF7f6000Party members if travelers are available you can switch places.^-~ DO ~SetGlobal("JO_JOIN_Move_Around","GLOBAL",29)~ EXIT //
-
+	IF ~~ THEN REPLY ~Switch party menu~ GOTO SWITCH_PARTY
 
 	IF ~~ THEN REPLY ~^GI like to ...^-~ GOTO 1 //
 
@@ -617,4 +611,20 @@ IF ~~ THEN BEGIN INDEPENDANCE
 	IF ~Global("JO_JOIN_NOINDEPANDANCE","GLOBAL",0)~ THEN REPLY ~^0xFF5b5b5bI am pretty independant, don't follow me when I walk 50 steps away from the group !^-~ DO ~SetGlobal("JO_JOIN_Move_Around","GLOBAL",20)~ EXIT //
 	IF ~Global("JO_JOIN_NOINDEPANDANCE","GLOBAL",0)~ THEN REPLY ~^0xFF5b5b5bI am pretty independant, don't follow me when I walk 80 steps away from the group !^-~ DO ~SetGlobal("JO_JOIN_Move_Around","GLOBAL",21)~ EXIT //
 	IF ~Global("JO_JOIN_NOINDEPANDANCE","GLOBAL",0)~ THEN REPLY ~^0xFF5b5b5bI am pretty independant, don't follow me when I walk 100 steps away from the group !^-~ DO ~SetGlobal("JO_JOIN_Move_Around","GLOBAL",22)~ EXIT 
+END
+
+// Switch party
+IF ~~ THEN BEGIN SWITCH_PARTY
+	SAY ~Switch party menu~
+	IF ~~ THEN REPLY ~Go back~ GOTO 0
+	IF ~Global("JO_JOIN_NO_SWITCHING_PARTY","GLOBAL",0)~ THEN REPLY ~Deactive Switch party~ DO ~SetGlobal("JO_JOIN_NO_SWITCHING_PARTY","GLOBAL",1)~ GOTO 0
+	IF ~!Global("JO_JOIN_NO_SWITCHING_PARTY","GLOBAL",0)~ THEN REPLY ~^GActive Switch party^-~ DO ~SetGlobal("JO_JOIN_NO_SWITCHING_PARTY","GLOBAL",0)~ GOTO 0
+	IF ~Global("JO_JOIN_NO_SWITCHING_PARTY","GLOBAL",0) Global("JO_JOIN_Move_Around","GLOBAL",0)~ THEN REPLY ~^0xFF5b5b5bTravelers stop switching places with party members.^-~ DO ~SetGlobal("JO_JOIN_Move_Around","GLOBAL",10)~ EXIT //
+	IF ~Global("JO_JOIN_NO_SWITCHING_PARTY","GLOBAL",0) Global("JO_JOIN_Move_Around","GLOBAL",0)~ THEN REPLY ~^0xFF7f6000Travelers if party members are available you can switch places.^-~ DO ~SetGlobal("JO_JOIN_Move_Around","GLOBAL",11)~ EXIT //
+	IF ~Global("JO_JOIN_NO_SWITCHING_PARTY","GLOBAL",0) !Global("JO_JOIN_PS_SAFE_SLOT","GLOBAL",0)~ THEN REPLY ~^0xFF6aa84fTravelers you can switch places with every party members !^-~ DO ~SetGlobal("JO_JOIN_PS_SAFE_SLOT","GLOBAL",0)~ EXIT //
+	IF ~Global("JO_JOIN_NO_SWITCHING_PARTY","GLOBAL",0) !Global("JO_JOIN_PS_SAFE_SLOT","GLOBAL",3)~ THEN REPLY ~^0xFF16537eTravelers you can switch places only with the last three party member !^-~ DO ~SetGlobal("JO_JOIN_PS_SAFE_SLOT","GLOBAL",3)~ EXIT //
+	IF ~Global("JO_JOIN_NO_SWITCHING_PARTY","GLOBAL",0) !Global("JO_JOIN_PS_SAFE_SLOT","GLOBAL",4)~ THEN REPLY ~^0xFF16537eTravelers you can switch places only with the last two party member !^-~ DO ~SetGlobal("JO_JOIN_PS_SAFE_SLOT","GLOBAL",4)~ EXIT //
+	IF ~Global("JO_JOIN_NO_SWITCHING_PARTY","GLOBAL",0) !Global("JO_JOIN_PS_SAFE_SLOT","GLOBAL",5)~ THEN REPLY ~^0xFF16537eTravelers you can switch places only with the last party member !^-~ DO ~SetGlobal("JO_JOIN_PS_SAFE_SLOT","GLOBAL",5)~ EXIT //
+	IF ~Global("JO_JOIN_NO_SWITCHING_PARTY","GLOBAL",0) Global("JO_JOIN_Move_Around","GLOBAL",0)~ THEN REPLY ~^0xFF5b5b5bParty members stop switching places with travelers.^-~ DO ~SetGlobal("JO_JOIN_Move_Around","GLOBAL",28)~ EXIT //
+	IF ~Global("JO_JOIN_NO_SWITCHING_PARTY","GLOBAL",0) Global("JO_JOIN_Move_Around","GLOBAL",0)~ THEN REPLY ~^0xFF7f6000Party members if travelers are available you can switch places.^-~ DO ~SetGlobal("JO_JOIN_Move_Around","GLOBAL",29)~ EXIT //
 END

--- a/JOining_Party_Select/D/JOJOINNE.D
+++ b/JOining_Party_Select/D/JOJOINNE.D
@@ -28,16 +28,7 @@ IF ~True()~ THEN BEGIN 0
 	IF ~~ THEN REPLY ~Sorry, I'm just trying to draw some attention...~ EXIT
 
 // Temporary : travelers switch
-	IF ~Global("JO_JOIN_Move_Around","GLOBAL",0)~ THEN REPLY ~^0xFF5b5b5bStop the Quick Switch for a while, please.^-~ DO ~SetGlobal("JO_JOIN_Move_Around","GLOBAL",3)~ EXIT // Reset when loading a save.
-	IF ~Global("JO_JOIN_Move_Around","GLOBAL",0)~ THEN REPLY ~^0xFF7f6000You are free to Quick Switch when you feel like.^-~ DO ~SetGlobal("JO_JOIN_Move_Around","GLOBAL",4)~ EXIT //
-	IF ~OR(2)
-			Global("JO_JOIN_AREA","MYAREA",1)
-			Global("JO_JOIN_BLOP","GLOBAL",1)
-		!Global("JO_JOIN_AREA_TRANSITION","GLOBAL",1) 
-		NumInPartyLT(6)
-		Global("JO_JOIN_Move_Around","GLOBAL",0)~ THEN REPLY ~^GLet's Quick Switch, one by one, quietly and in order.^-~ DO ~SetGlobal("JO_NOJOIN","GLOBAL",0) SetGlobal("JO_NOJOIN_LOCALS","LOCALS",0) SmallWait(1) SetGlobal("JO_JOIN_Move_Around","GLOBAL",7)~ EXIT //
-	IF ~!Global("JO_JOIN_BLOP","GLOBAL",1)
-		Global("JO_JOIN_AREA_TRANSITION","GLOBAL",1)~ THEN REPLY ~Quick Switch isn't available here.~ EXIT //
+	IF ~~ THEN REPLY ~Quick switch menu~ GOTO QUICK_SWITCH
 
 // Cutscenes
 	IF ~Global("JO_JOIN_Move_Around","GLOBAL",0)~ THEN REPLY ~^0xFF5b5b5bI don't want to see any of you in my dream.^-~ DO ~SetGlobal("JO_JOIN_Move_Around","GLOBAL",1)~ EXIT // Accounted for in JO_JOINI
@@ -627,4 +618,24 @@ IF ~~ THEN BEGIN SWITCH_PARTY
 	IF ~Global("JO_JOIN_NO_SWITCHING_PARTY","GLOBAL",0) !Global("JO_JOIN_PS_SAFE_SLOT","GLOBAL",5)~ THEN REPLY ~^0xFF16537eTravelers you can switch places only with the last party member !^-~ DO ~SetGlobal("JO_JOIN_PS_SAFE_SLOT","GLOBAL",5)~ EXIT //
 	IF ~Global("JO_JOIN_NO_SWITCHING_PARTY","GLOBAL",0) Global("JO_JOIN_Move_Around","GLOBAL",0)~ THEN REPLY ~^0xFF5b5b5bParty members stop switching places with travelers.^-~ DO ~SetGlobal("JO_JOIN_Move_Around","GLOBAL",28)~ EXIT //
 	IF ~Global("JO_JOIN_NO_SWITCHING_PARTY","GLOBAL",0) Global("JO_JOIN_Move_Around","GLOBAL",0)~ THEN REPLY ~^0xFF7f6000Party members if travelers are available you can switch places.^-~ DO ~SetGlobal("JO_JOIN_Move_Around","GLOBAL",29)~ EXIT //
+END
+
+// Quick switch
+IF ~~ THEN BEGIN QUICK_SWITCH
+	SAY ~Quick switch menu~
+	IF ~~ THEN REPLY ~Go back~ GOTO 0
+	IF ~Global("JO_JOIN_NO_QUICK_SWITCH","GLOBAL",0)~ THEN REPLY ~Deactive Quick switch~ DO ~SetGlobal("JO_JOIN_NO_QUICK_SWITCH","GLOBAL",1)~ GOTO 0
+	IF ~!Global("JO_JOIN_NO_QUICK_SWITCH","GLOBAL",0)~ THEN REPLY ~^GActive Quick switch^-~ DO ~SetGlobal("JO_JOIN_NO_QUICK_SWITCH","GLOBAL",0)~ GOTO 0
+	IF ~Global("JO_JOIN_NO_QUICK_SWITCH","GLOBAL",0) Global("JO_JOIN_Move_Around","GLOBAL",0)~ THEN REPLY ~^0xFF5b5b5bStop the Quick Switch for a while, please.^-~ DO ~SetGlobal("JO_JOIN_Move_Around","GLOBAL",3)~ EXIT // Reset when loading a save.
+	IF ~Global("JO_JOIN_NO_QUICK_SWITCH","GLOBAL",0) Global("JO_JOIN_Move_Around","GLOBAL",0)~ THEN REPLY ~^0xFF7f6000You are free to Quick Switch when you feel like.^-~ DO ~SetGlobal("JO_JOIN_Move_Around","GLOBAL",4)~ EXIT //
+	IF ~Global("JO_JOIN_NO_QUICK_SWITCH","GLOBAL",0)
+		OR(2)
+			!Global("JO_JOIN_AREA","MYAREA",0)
+			!Global("JO_JOIN_BLOP","GLOBAL",0)
+		Global("JO_JOIN_AREA_TRANSITION","GLOBAL",0) 
+		NumInPartyLT(6)
+		Global("JO_JOIN_Move_Around","GLOBAL",0)~ THEN REPLY ~^GLet's Quick Switch, one by one, quietly and in order.^-~ DO ~SetGlobal("JO_NOJOIN","GLOBAL",0) SetGlobal("JO_NOJOIN_LOCALS","LOCALS",0) SetGlobal("JO_JOIN_Move_Around","GLOBAL",7)~ EXIT //
+	IF ~Global("JO_JOIN_NO_QUICK_SWITCH","GLOBAL",0)
+		Global("JO_JOIN_BLOP","GLOBAL",0)
+		!Global("JO_JOIN_AREA_TRANSITION","GLOBAL",0)~ THEN REPLY ~Quick Switch isn't available here.~ EXIT //
 END


### PR DESCRIPTION
Pour tester, j'ai ajouté la GLOBAL `JO_JOIN_NOINDEPANDANCE` pour bloquer/activer le process d'indépendance.

Comme ça rajoute des entrées dans le dialogue déjà surchargé, je me suis permis d'en faire un sous-menu. Et de faire des expérimentations.

Menu par défaut quand lancé sur Player1 :

<img width="779" height="231" alt="image" src="https://github.com/user-attachments/assets/7b872272-7a0e-44b9-ab75-64f8aac22d27" />

Les options sont cachées lorsque le process est désactivé (on comprend bien qu'il est inactif).
<img width="395" height="100" alt="image" src="https://github.com/user-attachments/assets/e4d6280b-1737-49f8-b490-adbe35293af7" />

- `Go back` renvoie au menu principal.
- Modifier la GLOBAL renvoie sur le menu principal et permet de revenir dans le menu pour peaufiner la config (ou l'annuler)
- Modifier la LOCALS ferme le menu (comme précédemment)



Quand lancé sur un traveler :
<img width="738" height="178" alt="image" src="https://github.com/user-attachments/assets/4781f2ae-bd6e-4558-ac28-10bdb253bad9" />

- Dans le `SAY`, on a un `<GABBER>` qui rappelle le personnage avec lequel on parle
- On a pas d'information pour indiquer si la GLOBAL est active ou pas

Il faudrait retravailler la palette de couleurs (gris sur fond noir n'est pas assez lisible), j'ai ajouté un point sur la roadmap.
J'aurais aimé colorer le `X steps` dans une autre couleur, mais ça casse la couleur pour le reste de la strref (qui s'affiche en blanc)

edit : on pourrait ajouter un petit descriptif du process dans le menu pour clarifier son rôle